### PR TITLE
Fix MoveList.getFen don't see the last move

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -652,7 +652,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @return
      */
     public String getFen() {
-        return getFen(this.size() - 1);
+        return getFen(this.size() );
     }
 
     /**

--- a/src/test/java/com/github/bhlangonijr/chesslib/move/MoveListTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/move/MoveListTest.java
@@ -7,6 +7,29 @@ import static org.junit.Assert.assertEquals;
 public class MoveListTest {
 
     @Test
+    public void testMoveListStartingPosition() throws MoveConversionException {
+        String[] san = {"e4", "e4 e6", "e4 e6 f4"};
+        String[] fen = {"rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 2",
+                        "rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3",
+                        "rnbqkbnr/pppp1ppp/4p3/8/4PP2/8/PPPP2PP/RNBQKBNR b KQkq f3 0 4"};
+
+        for (int i=0; i<3; i++) {
+            MoveList list = new MoveList();
+            list.loadFromSan(san[i]);
+            list.getFen();
+            assertEquals(fen[i], list.getFen());
+        }
+    }
+
+    @Test
+    public void testMoveListSmall() throws MoveConversionException {
+        String san = "e4 Nc6 d4 Nf6 d5 Ne5 Nf3 d6 Nxe5 dxe5 Bb5+ Bd7 Bxd7+ Qxd7 Nc3 e6 O-O exd5 ";
+        MoveList list1 = new MoveList();
+        list1.loadFromSan(san);
+        assertEquals("r3kb1r/pppq1ppp/5n2/3pp3/4P3/2N5/PPP2PPP/R1BQ1RK1 w kq - 0 19" , list1.getFen());
+    }
+
+    @Test
     public void testMoveList() throws MoveConversionException {
 
         String s = "e2e4 b8c6 d2d4 g8f6 d4d5 c6e5 g1f3 d7d6 f3e5 d6e5 f1b5 c8d7 b5d7 d8d7 b1c3 e7e6 e1g1 e6d5";
@@ -41,7 +64,7 @@ public class MoveListTest {
                 "Qxe4 47.Qxg7+ Kxg7 48.h6+ Kh8";
         MoveList list = new MoveList();
         list.loadFromSan(moveText);
-        assertEquals("8/6k1/7P/6K1/pr2q3/6p1/8/8 b - - 0 96", list.getFen());
+        assertEquals("7k/8/7P/6K1/pr2q3/6p1/8/8 w - - 1 97", list.getFen());
     }
 
     @Test
@@ -64,7 +87,7 @@ public class MoveListTest {
                 "Nd5 88.Ke6 Nc7+";
         MoveList list = new MoveList();
         list.loadFromSan(moveText);
-        assertEquals("8/7R/2P1K3/3n4/8/6b1/6kp/8 b - - 6 176", list.getFen());
+        assertEquals("8/2n4R/2P1K3/8/8/6b1/6kp/8 w - - 7 177", list.getFen());
     }
 
     @Test
@@ -82,7 +105,7 @@ public class MoveListTest {
                 "Ra4 57.Kf2 Rxh4 58.Be3 ";
         MoveList list = new MoveList();
         list.loadFromSan(moveText);
-        assertEquals("8/8/4k2B/4r3/7r/5P2/3R1KP1/8 w - - 0 115", list.getFen());
+        assertEquals("8/8/4k3/4r3/7r/4BP2/3R1KP1/8 b - - 1 116", list.getFen());
 
     }
 }


### PR DESCRIPTION
1. MoveList.getFen gives wrong answer if halfmoves from starting positions > 1 (method returned the same with " e4 " and " e4 e5 " moves) So, test class updated too. 

2. FEN notation in last field have counter of full moves, which incremented after black move not after each halfmove. How about changing it?