### PR TITLE
Add methods to view the board from either player's view point

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -1507,14 +1507,34 @@ public class Board implements Cloneable, BoardEvent {
         return keys.get(57 * piece.ordinal() + 13 * square.ordinal());
     }
 
+    /**
+     * Returns a string representation of the board with the 1st rank at the bottom,
+     * similarly to the {@link #toString()} method but without the info on whose turn it is.
+     *
+     * @return A string representation of the board from the White player's point of view.
+     * @since 1.4.0
+     */
     public String toStringFromWhiteViewPoint() {
         return toStringFromViewPoint(Side.WHITE);
     }
 
+    /**
+     * Returns a string representation of the board with the 8th rank at the bottom
+     *
+     * @return A string representation of the board from the Black player's point of view.
+     * @since 1.4.0
+     */
     public String toStringFromBlackViewPoint() {
         return toStringFromViewPoint(Side.BLACK);
     }
 
+    /**
+     * Returns a string representation of the board from the given player's point of view.
+     *
+     * @param side The side whose home rank should be at the bottom of the resulting representation.
+     * @return A string representation of the board from the given player's point of view.
+     * @since 1.4.0
+     */
     public String toStringFromViewPoint(Side side) {
         StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -24,6 +24,8 @@ import com.github.bhlangonijr.chesslib.util.XorShiftRandom;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static com.github.bhlangonijr.chesslib.Bitboard.extractLsb;
 import static com.github.bhlangonijr.chesslib.Constants.emptyMove;
@@ -1505,13 +1507,25 @@ public class Board implements Cloneable, BoardEvent {
         return keys.get(57 * piece.ordinal() + 13 * square.ordinal());
     }
 
-    @Override
-    public String toString() {
+    public String toStringFromWhiteViewPoint() {
+        return toStringFromViewPoint(Side.WHITE);
+    }
+
+    public String toStringFromBlackViewPoint() {
+        return toStringFromViewPoint(Side.BLACK);
+    }
+
+    public String toStringFromViewPoint(Side side) {
         StringBuilder sb = new StringBuilder();
 
-        for (int i = 7; i >= 0; i--) {
+        final Supplier<IntStream> rankIterator = side == Side.WHITE
+                ? Board::sevenToZero : Board::zeroToSeven;
+        final Supplier<IntStream> fileIterator = side == Side.WHITE
+                ? Board::zeroToSeven : Board::sevenToZero;
+
+        rankIterator.get().forEach(i -> {
             Rank r = Rank.allRanks[i];
-            for (int n = 0; n <= 7; n++) {
+            fileIterator.get().forEach(n -> {
                 File f = File.allFiles[n];
                 if (!File.NONE.equals(f) && !Rank.NONE.equals(r)) {
                     Square sq = Square.encode(r, f);
@@ -1522,13 +1536,24 @@ public class Board implements Cloneable, BoardEvent {
                         sb.append(Constants.getPieceNotation(piece));
                     }
                 }
-            }
+            });
             sb.append("\n");
-        }
-        sb.append("Side: ");
-        sb.append(getSideToMove());
+        });
 
         return sb.toString();
+    }
+
+    private static IntStream zeroToSeven() {
+        return IntStream.iterate(0, i -> i + 1).limit(8);
+    }
+
+    private static IntStream sevenToZero() {
+        return IntStream.iterate(7, i -> i - 1).limit(8);
+    }
+
+    @Override
+    public String toString() {
+        return toStringFromWhiteViewPoint() + "Side: " + getSideToMove();
     }
 
     @Override

--- a/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
@@ -682,6 +682,52 @@ public class BoardTest {
     }
 
     @Test
+    public void testToStringFromWhiteViewPoint() throws MoveConversionException {
+
+        // Creates a new chessboard in the standard initial position
+        Board board = new Board();
+
+        board.doMove("e4");
+        board.doMove("Nc6");
+        board.doMove("Bc4");
+
+        final String expected =
+                "r.bqkbnr\n" +
+                "pppppppp\n" +
+                "..n.....\n" +
+                "........\n" +
+                "..B.P...\n" +
+                "........\n" +
+                "PPPP.PPP\n" +
+                "RNBQK.NR\n";
+        assertEquals(expected, board.toStringFromWhiteViewPoint());
+        assertEquals(expected, board.toStringFromViewPoint(Side.WHITE));
+    }
+
+    @Test
+    public void testToStringFromBlackViewPoint() throws MoveConversionException {
+
+        // Creates a new chessboard in the standard initial position
+        Board board = new Board();
+
+        board.doMove("e4");
+        board.doMove("Nc6");
+        board.doMove("Bc4");
+
+        final String expected =
+                "RN.KQBNR\n" +
+                "PPP.PPPP\n" +
+                "........\n" +
+                "...P.B..\n" +
+                "........\n" +
+                ".....n..\n" +
+                "pppppppp\n" +
+                "rnbkqb.r\n";
+        assertEquals(expected, board.toStringFromBlackViewPoint());
+        assertEquals(expected, board.toStringFromViewPoint(Side.BLACK));
+    }
+
+    @Test
     public void testBoardStrictEquals() throws MoveConversionException {
 
         Board board = new Board();

--- a/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
@@ -661,11 +661,24 @@ public class BoardTest {
         // Creates a new chessboard in the standard initial position
         Board board = new Board();
 
-        //Make a move from E2 to E4 squares
         board.doMove(new Move(Square.E2, Square.E4));
+        board.doMove(new Move(Square.B8, Square.C6));
+        board.doMove(new Move(Square.F1, Square.C4));
 
         //print the chessboard in a human-readable form
         System.out.println(board.toString());
+
+        final String expected =
+                "r.bqkbnr\n" +
+                "pppppppp\n" +
+                "..n.....\n" +
+                "........\n" +
+                "..B.P...\n" +
+                "........\n" +
+                "PPPP.PPP\n" +
+                "RNBQK.NR\n" +
+                "Side: BLACK";
+        assertEquals(expected, board.toString());
     }
 
     @Test


### PR DESCRIPTION
Greetings,

I figured it would be useful (for me, at least!) if you could view the board from either player's view point. The current `toString()` method of the `Board` class always renders the board so that White is at the bottom.

With this pull request I introduce new methods for the `Board` class: 

* `toStringFromWhiteViewPoint()`
* `toStringFromBlackViewPoint()`
* `toStringFromViewPoint(Side side)`

The first one renders the board as if it was the White player looking at it, i.e. the 1st rank at the bottom. The second one renders the board as if it was the Black player looking at it, i.e. the 8th rank at the bottom. The third method allows you to specify the side as a parameter. Internally, the first and second method refer to the third one. Similarly, the old `toString()` method refers to the first one, and then just appends the info on whose turn it is. I also created unit tests for all of these methods, including the old `toString()` which kind of had a test but without any assertions.

I figured I could do this feature quicker than I could create a pull request that would explain everything that I would need, so I just went ahead and did it before asking, I hope you don't mind. 😃 