### PR TITLE
Numbered move lists

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -382,15 +382,38 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
 
     /**
      * Converts the MoveList into short algebraic notation (SAN) representation
+     * without move numbers, e.g. "e4 e5 Nf3 Bc5".
      *
      * @return string
      * @throws MoveConversionException the move conversion exception
+     * @see #toSanWithMoveNumbers()
      */
     public String toSan() throws MoveConversionException {
         StringBuilder sb = new StringBuilder();
         for (String sanMove : this.toSanArray()) {
             sb.append(sanMove);
             sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Converts the MoveList into short algebraic notation (SAN) representation
+     * with move numbers, e.g. "1. e4 e5 2. Nf3 Bc5".
+     *
+     * @return string
+     * @throws MoveConversionException the move conversion exception
+     * @see #toSan()
+     * @since 1.4.0
+     */
+    public String toSanWithMoveNumbers() throws MoveConversionException {
+        StringBuilder sb = new StringBuilder();
+        final String[] sanArray = this.toSanArray();
+        for (int halfMove = 0; halfMove < sanArray.length; halfMove++) {
+            if (halfMove % 2 == 0) {
+                sb.append((halfMove / 2) + 1).append(". ");
+            }
+            sb.append(sanArray[halfMove]).append(" ");
         }
         return sb.toString();
     }

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -420,15 +420,38 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
 
     /**
      * Converts the MoveList into figurine algebraic notation (FAN) representation
+     * without move numbers, e.g. "♙e4 ♟e5 ♘f3 ♝c5".
      *
      * @return string
      * @throws MoveConversionException the move conversion exception
+     * @see #toFanWithMoveNumbers()
      */
     public String toFan() throws MoveConversionException {
         StringBuilder sb = new StringBuilder();
         for (String fanMove : this.toFanArray()) {
             sb.append(fanMove);
             sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Converts the MoveList into figurine algebraic notation (FAN) representation
+     * with move numbers, e.g. "1. ♙e4 ♟e5 2. ♘f3 ♝c5".
+     *
+     * @return string
+     * @throws MoveConversionException the move conversion exception
+     * @see #toFan()
+     * @since 1.4.0
+     */
+    public String toFanWithMoveNumbers() throws MoveConversionException {
+        StringBuilder sb = new StringBuilder();
+        final String[] fanArray = this.toFanArray();
+        for (int halfMove = 0; halfMove < fanArray.length; halfMove++) {
+            if (halfMove % 2 == 0) {
+                sb.append((halfMove / 2) + 1).append(". ");
+            }
+            sb.append(fanArray[halfMove]).append(" ");
         }
         return sb.toString();
     }

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -389,12 +389,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @see #toSanWithMoveNumbers()
      */
     public String toSan() throws MoveConversionException {
-        StringBuilder sb = new StringBuilder();
-        for (String sanMove : this.toSanArray()) {
-            sb.append(sanMove);
-            sb.append(" ");
-        }
-        return sb.toString();
+        return toStringWithoutMoveNumbers(toSanArray());
     }
 
     /**
@@ -407,15 +402,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @since 1.4.0
      */
     public String toSanWithMoveNumbers() throws MoveConversionException {
-        StringBuilder sb = new StringBuilder();
-        final String[] sanArray = this.toSanArray();
-        for (int halfMove = 0; halfMove < sanArray.length; halfMove++) {
-            if (halfMove % 2 == 0) {
-                sb.append((halfMove / 2) + 1).append(". ");
-            }
-            sb.append(sanArray[halfMove]).append(" ");
-        }
-        return sb.toString();
+        return toStringWithMoveNumbers(toSanArray());
     }
 
     /**
@@ -427,12 +414,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @see #toFanWithMoveNumbers()
      */
     public String toFan() throws MoveConversionException {
-        StringBuilder sb = new StringBuilder();
-        for (String fanMove : this.toFanArray()) {
-            sb.append(fanMove);
-            sb.append(" ");
-        }
-        return sb.toString();
+        return toStringWithoutMoveNumbers(toFanArray());
     }
 
     /**
@@ -445,13 +427,26 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @since 1.4.0
      */
     public String toFanWithMoveNumbers() throws MoveConversionException {
+        return toStringWithMoveNumbers(toFanArray());
+    }
+
+
+    private String toStringWithoutMoveNumbers(String[] moveArray) throws MoveConversionException {
         StringBuilder sb = new StringBuilder();
-        final String[] fanArray = this.toFanArray();
-        for (int halfMove = 0; halfMove < fanArray.length; halfMove++) {
+        for (String move : moveArray) {
+            sb.append(move);
+            sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    private String toStringWithMoveNumbers(String[] moveArray) throws MoveConversionException {
+        StringBuilder sb = new StringBuilder();
+        for (int halfMove = 0; halfMove < moveArray.length; halfMove++) {
             if (halfMove % 2 == 0) {
                 sb.append((halfMove / 2) + 1).append(". ");
             }
-            sb.append(fanArray[halfMove]).append(" ");
+            sb.append(moveArray[halfMove]).append(" ");
         }
         return sb.toString();
     }

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -381,7 +381,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Converts the MoveList into SAN representation
+     * Converts the MoveList into short algebraic notation (SAN) representation
      *
      * @return string
      * @throws MoveConversionException the move conversion exception
@@ -396,7 +396,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Converts the MoveList into FAN representation
+     * Converts the MoveList into figurine algebraic notation (FAN) representation
      *
      * @return string
      * @throws MoveConversionException the move conversion exception
@@ -411,7 +411,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Converts the MoveList into SAN Array representation
+     * Converts the MoveList into short algebraic notation (SAN) array representation
      *
      * @return string [ ]
      * @throws MoveConversionException the move conversion exception
@@ -426,7 +426,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Converts the MoveList into FAN Array representation
+     * Converts the MoveList into figurine algebraic notation (FAN) array representation
      *
      * @return string [ ]
      * @throws MoveConversionException the move conversion exception
@@ -467,7 +467,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Gets start fen.
+     * Gets start board position as a Forsyth–Edwards Notation (FEN) string.
      *
      * @return the startFEN
      */
@@ -476,7 +476,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * load from long algebraic text
+     * Load from long algebraic text
      *
      * @param text the text
      * @throws MoveConversionException the move conversion exception
@@ -503,7 +503,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Add a move in the SAN format
+     * Add a move in the short algebraic notation (SAN) format
      *
      * @param san the san
      * @throws MoveConversionException the move conversion exception
@@ -513,7 +513,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Add a move in the SAN format
+     * Add a move in the short algebraic notation (SAN) format
      *
      * @param san            the san
      * @param replay         the replay
@@ -546,7 +546,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * load from SAN text
+     * Load from short algebraic notation (SAN) text
      *
      * @param text the text
      * @throws MoveConversionException the move conversion exception
@@ -582,7 +582,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
     }
 
     /**
-     * Decode san to Move move.
+     * Decode short algebraic notation (SAN) to a {@link Move].
      *
      * @param board the board
      * @param san   the san

--- a/src/test/java/com/github/bhlangonijr/chesslib/move/MoveListTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/move/MoveListTest.java
@@ -71,7 +71,7 @@ public class MoveListTest {
     }
 
     /**
-     * Test that a move list can be returned with move numbers.
+     * Test that a SAN move list can be returned with move numbers.
      */
     @Test
     public void testToSanWithMoveNumbers() {
@@ -100,6 +100,33 @@ public class MoveListTest {
         list = new MoveList();
         list.loadFromSan(expectedSan);
         assertEquals(expectedSan, list.toSanWithMoveNumbers());
+    }
+
+    /**
+     * Test that a FAN move list can be returned with move numbers.
+     */
+    @Test
+    public void testToFanWithMoveNumbers() {
+        // No moves yet:
+        String s = "";
+        String expectedFan = "";
+        MoveList list = new MoveList();
+        assertEquals(expectedFan, list.toFan());
+        assertEquals(expectedFan, list.toFanWithMoveNumbers());
+
+        // Ends with a move by Black:
+        s = "e2e4 b8c6 d2d4 g8f6 d4d5 c6e5 g1f3 d7d6 f3e5 d6e5 f1b5 c8d7 b5d7 d8d7 b1c3 e7e6";
+        expectedFan = "1. ♙e4 ♞c6 2. ♙d4 ♞f6 3. ♙d5 ♞e5 4. ♘f3 ♟d6 5. ♘xe5 ♟dxe5 6. ♗b5+ ♝d7 7. ♗xd7+ ♛xd7 8. ♘c3 ♟e6 ";
+        list = new MoveList();
+        list.loadFromText(s);
+        assertEquals(expectedFan, list.toFanWithMoveNumbers());
+
+        // Ends with a move by White:
+        s = "e2e4 b8c6 d2d4 g8f6 d4d5 c6e5 g1f3 d7d6 f3e5 d6e5 f1b5 c8d7 b5d7 d8d7 b1c3";
+        expectedFan = "1. ♙e4 ♞c6 2. ♙d4 ♞f6 3. ♙d5 ♞e5 4. ♘f3 ♟d6 5. ♘xe5 ♟dxe5 6. ♗b5+ ♝d7 7. ♗xd7+ ♛xd7 8. ♘c3 ";
+        list = new MoveList();
+        list.loadFromText(s);
+        assertEquals(expectedFan, list.toFanWithMoveNumbers());
     }
 
     /**

--- a/src/test/java/com/github/bhlangonijr/chesslib/move/MoveListTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/move/MoveListTest.java
@@ -71,6 +71,38 @@ public class MoveListTest {
     }
 
     /**
+     * Test that a move list can be returned with move numbers.
+     */
+    @Test
+    public void testToSanWithMoveNumbers() {
+        // No moves yet:
+        String s = "";
+        String expectedSan = "";
+        MoveList list = new MoveList();
+        assertEquals(expectedSan, list.toSan());
+        assertEquals(expectedSan, list.toSanWithMoveNumbers());
+
+        // Ends with a move by Black:
+        s = "e2e4 b8c6 d2d4 g8f6 d4d5 c6e5 g1f3 d7d6 f3e5 d6e5 f1b5 c8d7 b5d7 d8d7 b1c3 e7e6";
+        expectedSan = "1. e4 Nc6 2. d4 Nf6 3. d5 Ne5 4. Nf3 d6 5. Nxe5 dxe5 6. Bb5+ Bd7 7. Bxd7+ Qxd7 8. Nc3 e6 ";
+        list = new MoveList();
+        list.loadFromText(s);
+        assertEquals(expectedSan, list.toSanWithMoveNumbers());
+
+        // Ends with a move by White:
+        s = "e2e4 b8c6 d2d4 g8f6 d4d5 c6e5 g1f3 d7d6 f3e5 d6e5 f1b5 c8d7 b5d7 d8d7 b1c3";
+        expectedSan = "1. e4 Nc6 2. d4 Nf6 3. d5 Ne5 4. Nf3 d6 5. Nxe5 dxe5 6. Bb5+ Bd7 7. Bxd7+ Qxd7 8. Nc3 ";
+        list = new MoveList();
+        list.loadFromText(s);
+        assertEquals(expectedSan, list.toSanWithMoveNumbers());
+
+        // Read a SAN string with numbers, assert that the same string is returned:
+        list = new MoveList();
+        list.loadFromSan(expectedSan);
+        assertEquals(expectedSan, list.toSanWithMoveNumbers());
+    }
+
+    /**
      * Test move list pgn 1.
      *
      * @throws MoveConversionException the move conversion exception


### PR DESCRIPTION
This pull request adds two useful methods that can be used to output a `MoveList` with move numbers: `toSanWithMoveNumbers()` and `toFanWithMoveNumbers()`. An example of the output of the former would be `"1. e4 e5 2. Nf3 Bc5 "` and an example of the output of the latter would be `"1. ♙e4 ♟e5 2. ♘f3 ♝c5 "`.

Both methods have javadocs and unit tests, and I even refactored the repetitive parts so that it's pretty clean. I also took a shot at improving the javadocs of some other, related methods a bit.