### PR TITLE
Pieces should be able to tell their algebraic (SAN & FAN) notation

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -712,7 +712,7 @@ public class Board implements Cloneable, BoardEvent {
                     file += Integer.parseInt(c + "");
                 } else {
                     Square sq = Square.encode(Rank.allRanks[rank], File.allFiles[file]);
-                    setPiece(Constants.getPieceByNotation(c + ""), sq);
+                    setPiece(Piece.fromFenSymbol(String.valueOf(c)), sq);
                     file++;
                 }
             }
@@ -811,7 +811,7 @@ public class Board implements Cloneable, BoardEvent {
                         if (count > 0) {
                             fen.append(count);
                         }
-                        fen.append(Constants.getPieceNotation(piece));
+                        fen.append(piece.getFenSymbol());
                         count = 0;
                     } else {
                         count++;
@@ -1550,11 +1550,7 @@ public class Board implements Cloneable, BoardEvent {
                 if (!File.NONE.equals(f) && !Rank.NONE.equals(r)) {
                     Square sq = Square.encode(r, f);
                     Piece piece = getPiece(sq);
-                    if (Piece.NONE.equals(piece)) {
-                        sb.append(".");
-                    } else {
-                        sb.append(Constants.getPieceNotation(piece));
-                    }
+                    sb.append(piece.getFenSymbol());
                 }
             });
             sb.append("\n");

--- a/src/main/java/com/github/bhlangonijr/chesslib/Constants.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Constants.java
@@ -97,12 +97,18 @@ public class Constants {
 
     /**
      * The constant pieceNotation.
+     *
+     * @deprecated Use {@link Piece#getFenSymbol()} instead.
      */
+    @Deprecated
     public static final EnumMap<Piece, String> pieceNotation =
             new EnumMap<Piece, String>(Piece.class);
     /**
      * The constant pieceNotationR.
+     *
+     * @deprecated Use {@link Piece#fromFenSymbol(String)} instead.
      */
+    @Deprecated
     public static final Map<String, Piece> pieceNotationR =
             new HashMap<String, Piece>(12);
 
@@ -163,22 +169,26 @@ public class Constants {
     }
 
     /**
-     * gets the notation of a piece
+     * Gets the Forsyth-Edwards notation of a piece
      *
      * @param piece the piece
      * @return piece notation
+     * @deprecated Use {@link Piece#getFenSymbol()} instead.
      */
+    @Deprecated
     public static String getPieceNotation(Piece piece) {
-        return pieceNotation.get(piece);
+        return piece.getFenSymbol();
     }
 
     /**
-     * gets the piece by its notation
+     * Gets the piece by its Forsyth-Edwards notation
      *
      * @param notation the notation
      * @return piece by notation
+     * @deprecated Use {@link Piece#fromFenSymbol(String)} instead.
      */
+    @Deprecated
     public static Piece getPieceByNotation(String notation) {
-        return pieceNotationR.get(notation);
+        return Piece.fromFenSymbol(notation);
     }
 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/Piece.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Piece.java
@@ -26,68 +26,58 @@ public enum Piece {
     /**
      * White pawn piece.
      */
-    WHITE_PAWN,
+    WHITE_PAWN(Side.WHITE, PieceType.PAWN),
     /**
      * White knight piece.
      */
-    WHITE_KNIGHT,
+    WHITE_KNIGHT(Side.WHITE, PieceType.KNIGHT),
     /**
      * White bishop piece.
      */
-    WHITE_BISHOP,
+    WHITE_BISHOP(Side.WHITE, PieceType.BISHOP),
     /**
      * White rook piece.
      */
-    WHITE_ROOK,
+    WHITE_ROOK(Side.WHITE, PieceType.ROOK),
     /**
      * White queen piece.
      */
-    WHITE_QUEEN,
+    WHITE_QUEEN(Side.WHITE, PieceType.QUEEN),
     /**
      * White king piece.
      */
-    WHITE_KING,
+    WHITE_KING(Side.WHITE, PieceType.KING),
     /**
      * Black pawn piece.
      */
-    BLACK_PAWN,
+    BLACK_PAWN(Side.BLACK, PieceType.PAWN),
     /**
      * Black knight piece.
      */
-    BLACK_KNIGHT,
+    BLACK_KNIGHT(Side.BLACK, PieceType.KNIGHT),
     /**
      * Black bishop piece.
      */
-    BLACK_BISHOP,
+    BLACK_BISHOP(Side.BLACK, PieceType.BISHOP),
     /**
      * Black rook piece.
      */
-    BLACK_ROOK,
+    BLACK_ROOK(Side.BLACK, PieceType.ROOK),
     /**
      * Black queen piece.
      */
-    BLACK_QUEEN,
+    BLACK_QUEEN(Side.BLACK, PieceType.QUEEN),
     /**
      * Black king piece.
      */
-    BLACK_KING,
+    BLACK_KING(Side.BLACK, PieceType.KING),
     /**
      * None piece.
      */
-    NONE;
+    NONE(null, null);
 
     public static Piece[] allPieces = values();
 
-    /**
-     * The Piece type.
-     */
-    static EnumMap<Piece, PieceType> pieceType =
-            new EnumMap<Piece, PieceType>(Piece.class);
-    /**
-     * The Piece side.
-     */
-    static EnumMap<Piece, Side> pieceSide =
-            new EnumMap<Piece, Side>(Piece.class);
     private static Piece[][] pieceMake = {
             {WHITE_PAWN, BLACK_PAWN},
             {WHITE_KNIGHT, BLACK_KNIGHT},
@@ -98,36 +88,12 @@ public enum Piece {
             {NONE, NONE},
     };
 
-    static {
-        pieceType.put(Piece.WHITE_PAWN, PieceType.PAWN);
-        pieceType.put(Piece.WHITE_KNIGHT, PieceType.KNIGHT);
-        pieceType.put(Piece.WHITE_BISHOP, PieceType.BISHOP);
-        pieceType.put(Piece.WHITE_ROOK, PieceType.ROOK);
-        pieceType.put(Piece.WHITE_QUEEN, PieceType.QUEEN);
-        pieceType.put(Piece.WHITE_KING, PieceType.KING);
+    private final Side side;
+    private final PieceType type;
 
-        pieceType.put(Piece.BLACK_PAWN, PieceType.PAWN);
-        pieceType.put(Piece.BLACK_KNIGHT, PieceType.KNIGHT);
-        pieceType.put(Piece.BLACK_BISHOP, PieceType.BISHOP);
-        pieceType.put(Piece.BLACK_ROOK, PieceType.ROOK);
-        pieceType.put(Piece.BLACK_QUEEN, PieceType.QUEEN);
-        pieceType.put(Piece.BLACK_KING, PieceType.KING);
-
-        pieceSide.put(Piece.WHITE_PAWN, Side.WHITE);
-        pieceSide.put(Piece.WHITE_KNIGHT, Side.WHITE);
-        pieceSide.put(Piece.WHITE_BISHOP, Side.WHITE);
-        pieceSide.put(Piece.WHITE_ROOK, Side.WHITE);
-        pieceSide.put(Piece.WHITE_QUEEN, Side.WHITE);
-        pieceSide.put(Piece.WHITE_KING, Side.WHITE);
-
-        pieceSide.put(Piece.BLACK_PAWN, Side.BLACK);
-        pieceSide.put(Piece.BLACK_KNIGHT, Side.BLACK);
-        pieceSide.put(Piece.BLACK_BISHOP, Side.BLACK);
-        pieceSide.put(Piece.BLACK_ROOK, Side.BLACK);
-        pieceSide.put(Piece.BLACK_QUEEN, Side.BLACK);
-        pieceSide.put(Piece.BLACK_KING, Side.BLACK);
-
-
+    Piece(Side side, PieceType type) {
+        this.side = side;
+        this.type = type;
     }
 
     /**
@@ -167,7 +133,7 @@ public enum Piece {
      * @return the piece type
      */
     public PieceType getPieceType() {
-        return pieceType.get(this);
+        return type;
     }
 
     /**
@@ -176,6 +142,6 @@ public enum Piece {
      * @return the piece side
      */
     public Side getPieceSide() {
-        return pieceSide.get(this);
+        return side;
     }
 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/Piece.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Piece.java
@@ -16,8 +16,6 @@
 
 package com.github.bhlangonijr.chesslib;
 
-import java.util.EnumMap;
-
 /**
  * The enum Piece.
  */
@@ -26,55 +24,55 @@ public enum Piece {
     /**
      * White pawn piece.
      */
-    WHITE_PAWN(Side.WHITE, PieceType.PAWN),
+    WHITE_PAWN(Side.WHITE, PieceType.PAWN, "♙"),
     /**
      * White knight piece.
      */
-    WHITE_KNIGHT(Side.WHITE, PieceType.KNIGHT),
+    WHITE_KNIGHT(Side.WHITE, PieceType.KNIGHT, "♘"),
     /**
      * White bishop piece.
      */
-    WHITE_BISHOP(Side.WHITE, PieceType.BISHOP),
+    WHITE_BISHOP(Side.WHITE, PieceType.BISHOP, "♗"),
     /**
      * White rook piece.
      */
-    WHITE_ROOK(Side.WHITE, PieceType.ROOK),
+    WHITE_ROOK(Side.WHITE, PieceType.ROOK, "♖"),
     /**
      * White queen piece.
      */
-    WHITE_QUEEN(Side.WHITE, PieceType.QUEEN),
+    WHITE_QUEEN(Side.WHITE, PieceType.QUEEN, "♕"),
     /**
      * White king piece.
      */
-    WHITE_KING(Side.WHITE, PieceType.KING),
+    WHITE_KING(Side.WHITE, PieceType.KING, "♔"),
     /**
      * Black pawn piece.
      */
-    BLACK_PAWN(Side.BLACK, PieceType.PAWN),
+    BLACK_PAWN(Side.BLACK, PieceType.PAWN, "♟"),
     /**
      * Black knight piece.
      */
-    BLACK_KNIGHT(Side.BLACK, PieceType.KNIGHT),
+    BLACK_KNIGHT(Side.BLACK, PieceType.KNIGHT, "♞"),
     /**
      * Black bishop piece.
      */
-    BLACK_BISHOP(Side.BLACK, PieceType.BISHOP),
+    BLACK_BISHOP(Side.BLACK, PieceType.BISHOP, "♝"),
     /**
      * Black rook piece.
      */
-    BLACK_ROOK(Side.BLACK, PieceType.ROOK),
+    BLACK_ROOK(Side.BLACK, PieceType.ROOK, "♜"),
     /**
      * Black queen piece.
      */
-    BLACK_QUEEN(Side.BLACK, PieceType.QUEEN),
+    BLACK_QUEEN(Side.BLACK, PieceType.QUEEN, "♛"),
     /**
      * Black king piece.
      */
-    BLACK_KING(Side.BLACK, PieceType.KING),
+    BLACK_KING(Side.BLACK, PieceType.KING, "♚"),
     /**
      * None piece.
      */
-    NONE(null, null);
+    NONE(null, null, "NONE");
 
     public static Piece[] allPieces = values();
 
@@ -90,10 +88,12 @@ public enum Piece {
 
     private final Side side;
     private final PieceType type;
+    private String fanSymbol;
 
-    Piece(Side side, PieceType type) {
+    Piece(Side side, PieceType type, String fanSymbol) {
         this.side = side;
         this.type = type;
+        this.fanSymbol = fanSymbol;
     }
 
     /**
@@ -143,5 +143,27 @@ public enum Piece {
      */
     public Side getPieceSide() {
         return side;
+    }
+
+    /**
+     * Returns the short algebraic notation (SAN) symbol for this piece type.
+     * For example, "R" for a rook, "K" for a king, and an empty string for a pawn.
+     *
+     * @return The short algebraic notation symbol of this piece type.
+     * @since 1.4.0
+     */
+    public String getSanSymbol() {
+        return type.getSanSymbol();
+    }
+
+    /**
+     * Returns the figurine algebraic notation (FAN) symbol for this piece.
+     * For example, "♜" for a black rook, and "♙" for a white pawn.
+     *
+     * @return The figurine algebraic notation symbol of this piece type.
+     * @since 1.4.0
+     */
+    public String getFanSymbol() {
+        return fanSymbol;
     }
 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/Piece.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Piece.java
@@ -16,6 +16,9 @@
 
 package com.github.bhlangonijr.chesslib;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The enum Piece.
  */
@@ -24,55 +27,55 @@ public enum Piece {
     /**
      * White pawn piece.
      */
-    WHITE_PAWN(Side.WHITE, PieceType.PAWN, "♙"),
+    WHITE_PAWN(Side.WHITE, PieceType.PAWN, "♙", "P"),
     /**
      * White knight piece.
      */
-    WHITE_KNIGHT(Side.WHITE, PieceType.KNIGHT, "♘"),
+    WHITE_KNIGHT(Side.WHITE, PieceType.KNIGHT, "♘", "N"),
     /**
      * White bishop piece.
      */
-    WHITE_BISHOP(Side.WHITE, PieceType.BISHOP, "♗"),
+    WHITE_BISHOP(Side.WHITE, PieceType.BISHOP, "♗", "B"),
     /**
      * White rook piece.
      */
-    WHITE_ROOK(Side.WHITE, PieceType.ROOK, "♖"),
+    WHITE_ROOK(Side.WHITE, PieceType.ROOK, "♖", "R"),
     /**
      * White queen piece.
      */
-    WHITE_QUEEN(Side.WHITE, PieceType.QUEEN, "♕"),
+    WHITE_QUEEN(Side.WHITE, PieceType.QUEEN, "♕", "Q"),
     /**
      * White king piece.
      */
-    WHITE_KING(Side.WHITE, PieceType.KING, "♔"),
+    WHITE_KING(Side.WHITE, PieceType.KING, "♔", "K"),
     /**
      * Black pawn piece.
      */
-    BLACK_PAWN(Side.BLACK, PieceType.PAWN, "♟"),
+    BLACK_PAWN(Side.BLACK, PieceType.PAWN, "♟", "p"),
     /**
      * Black knight piece.
      */
-    BLACK_KNIGHT(Side.BLACK, PieceType.KNIGHT, "♞"),
+    BLACK_KNIGHT(Side.BLACK, PieceType.KNIGHT, "♞", "n"),
     /**
      * Black bishop piece.
      */
-    BLACK_BISHOP(Side.BLACK, PieceType.BISHOP, "♝"),
+    BLACK_BISHOP(Side.BLACK, PieceType.BISHOP, "♝", "b"),
     /**
      * Black rook piece.
      */
-    BLACK_ROOK(Side.BLACK, PieceType.ROOK, "♜"),
+    BLACK_ROOK(Side.BLACK, PieceType.ROOK, "♜", "r"),
     /**
      * Black queen piece.
      */
-    BLACK_QUEEN(Side.BLACK, PieceType.QUEEN, "♛"),
+    BLACK_QUEEN(Side.BLACK, PieceType.QUEEN, "♛", "q"),
     /**
      * Black king piece.
      */
-    BLACK_KING(Side.BLACK, PieceType.KING, "♚"),
+    BLACK_KING(Side.BLACK, PieceType.KING, "♚", "k"),
     /**
      * None piece.
      */
-    NONE(null, null, "NONE");
+    NONE(null, null, "NONE", ".");
 
     public static Piece[] allPieces = values();
 
@@ -86,14 +89,24 @@ public enum Piece {
             {NONE, NONE},
     };
 
+    private static final Map<String, Piece> fenToPiece = new HashMap<>(13);
+
+    static {
+        for (final Piece piece : Piece.values()) {
+            fenToPiece.put(piece.getFenSymbol(), piece);
+        }
+    }
+
     private final Side side;
     private final PieceType type;
     private String fanSymbol;
+    private String fenSymbol;
 
-    Piece(Side side, PieceType type, String fanSymbol) {
+    Piece(Side side, PieceType type, String fanSymbol, String fenSymbol) {
         this.side = side;
         this.type = type;
         this.fanSymbol = fanSymbol;
+        this.fenSymbol = fenSymbol;
     }
 
     /**
@@ -166,4 +179,32 @@ public enum Piece {
     public String getFanSymbol() {
         return fanSymbol;
     }
+
+    /**
+     * Returns the Forsyth-Edwards notation (FEN) symbol for this piece.
+     * For example, "r" for a black rook, and "P" for a white pawn.
+     *
+     * @return The Forsyth-Edwards Notation symbol of this piece.
+     * @since 1.4.0
+     */
+    public String getFenSymbol() {
+        return fenSymbol;
+    }
+
+    /**
+     * Returns the {@code Piece} corresponding to the given Forsyth-Edwards notation symbol.
+     *
+     * @param fenSymbol A piece symbol, such as "K", "b" or "p".
+     * @return the piece, such as {@code WHITE_KING}, {@code BLACK_BISHOP}, or {@code BLACK_PAWN}.
+     * throws IllegalArgumentException Thrown if the input does not correspond to any standard chess piece.
+     * @since 1.4.0
+     */
+    public static Piece fromFenSymbol(String fenSymbol) {
+        final Piece piece = fenToPiece.get(fenSymbol);
+        if (piece == null) {
+            throw new IllegalArgumentException(String.format("Unknown piece '%s'", fenSymbol));
+        }
+        return piece;
+    }
+
 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/PieceType.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/PieceType.java
@@ -16,6 +16,9 @@
 
 package com.github.bhlangonijr.chesslib;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The enum Piece type.
  */
@@ -24,31 +27,56 @@ public enum PieceType {
     /**
      * Pawn piece type.
      */
-    PAWN,
+    PAWN(""),
     /**
      * Knight piece type.
      */
-    KNIGHT,
+    KNIGHT("N"),
     /**
      * Bishop piece type.
      */
-    BISHOP,
+    BISHOP("B"),
     /**
      * Rook piece type.
      */
-    ROOK,
+    ROOK("R"),
     /**
      * Queen piece type.
      */
-    QUEEN,
+    QUEEN("Q"),
     /**
      * King piece type.
      */
-    KING,
+    KING("K"),
     /**
      * None piece type.
      */
-    NONE;
+    NONE("NONE");
+
+    private static final Map<String, PieceType> sanToType = new HashMap<>(7);
+
+    static {
+        for (final PieceType type : PieceType.values()) {
+            sanToType.put(type.getSanSymbol(), type);
+        }
+    }
+
+    private String sanSymbol;
+
+    PieceType(String sanSymbol) {
+        this.sanSymbol = sanSymbol;
+    }
+
+    /**
+     * Returns the short algebraic notation (SAN) symbol for this piece type.
+     * For example, "R" for a rook, "K" for a king, and an empty string for a pawn.
+     *
+     * @return The short algebraic notation symbol of this piece type.
+     * @since 1.4.0
+     */
+    public String getSanSymbol() {
+        return sanSymbol;
+    }
 
     /**
      * From value piece type.
@@ -58,6 +86,22 @@ public enum PieceType {
      */
     public static PieceType fromValue(String v) {
         return valueOf(v);
+    }
+
+    /**
+     * Returns the {@code PieceType} corresponding to the given short algebraic notation symbol.
+     *
+     * @param sanSymbol A piece symbol, such as "K", "B" or "".
+     * @return the piece type, such as {@code KING}, {@code BISHOP}, or {@code PAWN}.
+     * @throws IllegalArgumentException Thrown if the input does not correspond to any standard chess piece type.
+     * @since 1.4.0
+     */
+    public static PieceType fromSanSymbol(String sanSymbol) {
+        final PieceType pieceType = sanToType.get(sanSymbol);
+        if (pieceType == null) {
+            throw new IllegalArgumentException(String.format("Unknown piece '%s'", sanSymbol));
+        }
+        return pieceType;
     }
 
     /**

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/Move.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/Move.java
@@ -61,9 +61,9 @@ public class Move implements BoardEvent {
         this(Square.valueOf(move.substring(0, 2).toUpperCase()),
                 Square.valueOf(move.substring(2, 4).toUpperCase()),
                 move.length() < 5 ? Piece.NONE : Side.WHITE.equals(side) ?
-                        Constants.getPieceByNotation(
+                        Piece.fromFenSymbol(
                                 move.substring(4, 5).toUpperCase()) :
-                        Constants.getPieceByNotation(
+                        Piece.fromFenSymbol(
                                 move.substring(4, 5).toLowerCase()));
     }
 
@@ -115,7 +115,7 @@ public class Move implements BoardEvent {
     public String toString() {
         String promo = "";
         if (!Piece.NONE.equals(promotion)) {
-            promo = Constants.getPieceNotation(promotion);
+            promo = promotion.getFenSymbol();
         }
         return from.toString().toLowerCase() +
                 to.toString().toLowerCase() +

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -627,7 +627,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
                     san.toUpperCase());
         }
         Piece promotion = strPromotion.equals("") ? Piece.NONE :
-                Constants.getPieceByNotation(side.equals(Side.WHITE) ?
+                Piece.fromFenSymbol(side.equals(Side.WHITE) ?
                         strPromotion.toUpperCase() : strPromotion.toLowerCase());
 
         if (san.length() == 2) { //is pawn move

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -20,6 +20,7 @@ import com.github.bhlangonijr.chesslib.*;
 import com.github.bhlangonijr.chesslib.util.StringUtil;
 
 import java.util.*;
+import java.util.function.Function;
 
 /**
  * The type Move list.
@@ -34,54 +35,6 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
         }
     };
     private static final Move nullMove = new Move(Square.NONE, Square.NONE);
-
-    private static EnumMap<Piece, String> sanNotation =
-            new EnumMap<Piece, String>(Piece.class);
-
-    private static EnumMap<Piece, String> fanNotation =
-            new EnumMap<Piece, String>(Piece.class);
-
-    private static Map<String, PieceType> sanNotationR =
-            new HashMap<String, PieceType>(7);
-
-
-    static {
-        sanNotation.put(Piece.WHITE_PAWN, "");
-        sanNotation.put(Piece.BLACK_PAWN, "");
-        sanNotation.put(Piece.WHITE_KNIGHT, "N");
-        sanNotation.put(Piece.BLACK_KNIGHT, "N");
-        sanNotation.put(Piece.WHITE_BISHOP, "B");
-        sanNotation.put(Piece.BLACK_BISHOP, "B");
-        sanNotation.put(Piece.WHITE_ROOK, "R");
-        sanNotation.put(Piece.BLACK_ROOK, "R");
-        sanNotation.put(Piece.WHITE_QUEEN, "Q");
-        sanNotation.put(Piece.BLACK_QUEEN, "Q");
-        sanNotation.put(Piece.WHITE_KING, "K");
-        sanNotation.put(Piece.BLACK_KING, "K");
-        sanNotation.put(Piece.NONE, "NONE");
-
-        fanNotation.put(Piece.WHITE_PAWN, "♙");
-        fanNotation.put(Piece.BLACK_PAWN, "♟");
-        fanNotation.put(Piece.WHITE_KNIGHT, "♘");
-        fanNotation.put(Piece.BLACK_KNIGHT, "♞");
-        fanNotation.put(Piece.WHITE_BISHOP, "♗");
-        fanNotation.put(Piece.BLACK_BISHOP, "♝");
-        fanNotation.put(Piece.WHITE_ROOK, "♖");
-        fanNotation.put(Piece.BLACK_ROOK, "♜");
-        fanNotation.put(Piece.WHITE_QUEEN, "♕");
-        fanNotation.put(Piece.BLACK_QUEEN, "♛");
-        fanNotation.put(Piece.WHITE_KING, "♔");
-        fanNotation.put(Piece.BLACK_KING, "♚");
-        fanNotation.put(Piece.NONE, "NONE");
-
-        sanNotationR.put("", PieceType.PAWN);
-        sanNotationR.put("N", PieceType.KNIGHT);
-        sanNotationR.put("B", PieceType.BISHOP);
-        sanNotationR.put("R", PieceType.ROOK);
-        sanNotationR.put("Q", PieceType.QUEEN);
-        sanNotationR.put("K", PieceType.KING);
-        sanNotationR.put("NONE", PieceType.NONE);
-    }
 
     private final String startFEN;
     private boolean dirty = true;
@@ -136,7 +89,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      */
     // encode the move to SAN move and update thread local board
     protected static String encodeToSan(final Board board, Move move) throws MoveConversionException {
-        return encode(board, move, sanNotation);
+        return encode(board, move, Piece::getSanSymbol);
     }
 
     /**
@@ -149,7 +102,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      */
     // encode the move to SAN move and update thread local board
     protected static String encodeToFan(final Board board, Move move) throws MoveConversionException {
-        return encode(board, move, fanNotation);
+        return encode(board, move, Piece::getFanSymbol);
     }
 
     /**
@@ -162,7 +115,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @throws MoveConversionException the move conversion exception
      */
     // encode the move to SAN/FAN move and update thread local board
-    protected static String encode(final Board board, Move move, EnumMap<Piece, String> notation)
+    protected static String encode(final Board board, Move move, Function<Piece, String> notation)
             throws MoveConversionException {
         StringBuilder san = new StringBuilder();
         Piece piece = board.getPiece(move.getFrom());
@@ -182,7 +135,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
         boolean pawnMove = piece.getPieceType().equals(PieceType.PAWN) &&
                 move.getFrom().getFile().equals(move.getTo().getFile());
         boolean ambResolved = false;
-        san.append(notation.get(piece));
+        san.append(notation.apply(piece));
         if (!pawnMove) {
             //resolving ambiguous move
             long amb = board.squareAttackedByPieceType(move.getTo(),
@@ -226,7 +179,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
         san.append(move.getTo().toString().toLowerCase());
         if (!move.getPromotion().equals(Piece.NONE)) {
             san.append("=");
-            san.append(notation.get(move.getPromotion()));
+            san.append(notation.apply(move.getPromotion()));
         }
         addCheckFlag(board, san);
         return san.toString();
@@ -700,7 +653,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
             PieceType fromPiece = PieceType.PAWN;
 
             if (Character.isUpperCase(strFrom.charAt(0))) {
-                fromPiece = sanNotationR.get(strFrom.charAt(0) + "");
+                fromPiece = PieceType.fromSanSymbol(strFrom.charAt(0) + "");
             }
 
             if (strFrom.length() == 3) {

--- a/src/test/java/com/github/bhlangonijr/chesslib/PieceTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/PieceTest.java
@@ -91,4 +91,29 @@ public class PieceTest {
         assertEquals("BLACK_KING", Piece.BLACK_KING.value());
         assertEquals("NONE", Piece.NONE.value());
     }
+
+    @Test
+    public void fromFenSymbol() {
+        assertEquals(Piece.WHITE_PAWN, Piece.fromFenSymbol("P"));
+        assertEquals(Piece.WHITE_KNIGHT, Piece.fromFenSymbol("N"));
+        assertEquals(Piece.WHITE_BISHOP, Piece.fromFenSymbol("B"));
+        assertEquals(Piece.WHITE_ROOK, Piece.fromFenSymbol("R"));
+        assertEquals(Piece.WHITE_QUEEN, Piece.fromFenSymbol("Q"));
+        assertEquals(Piece.WHITE_KING, Piece.fromFenSymbol("K"));
+        assertEquals(Piece.BLACK_PAWN, Piece.fromFenSymbol("p"));
+        assertEquals(Piece.BLACK_KNIGHT, Piece.fromFenSymbol("n"));
+        assertEquals(Piece.BLACK_BISHOP, Piece.fromFenSymbol("b"));
+        assertEquals(Piece.BLACK_ROOK, Piece.fromFenSymbol("r"));
+        assertEquals(Piece.BLACK_QUEEN, Piece.fromFenSymbol("q"));
+        assertEquals(Piece.BLACK_KING, Piece.fromFenSymbol("k"));
+        assertEquals(Piece.NONE, Piece.fromFenSymbol("."));
+
+        try {
+            Piece.fromFenSymbol("X");
+            fail("There should have been an exception");
+        } catch (Exception expected) {
+            assertTrue(expected instanceof IllegalArgumentException);
+            assertEquals("Unknown piece 'X'", expected.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/github/bhlangonijr/chesslib/PieceTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/PieceTest.java
@@ -1,0 +1,94 @@
+package com.github.bhlangonijr.chesslib;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PieceTest {
+
+    @Test
+    public void getPieceType() {
+        assertEquals(PieceType.PAWN, Piece.WHITE_PAWN.getPieceType());
+        assertEquals(PieceType.PAWN, Piece.BLACK_PAWN.getPieceType());
+        assertEquals(PieceType.KNIGHT, Piece.WHITE_KNIGHT.getPieceType());
+        assertEquals(PieceType.KNIGHT, Piece.BLACK_KNIGHT.getPieceType());
+        assertEquals(PieceType.BISHOP, Piece.WHITE_BISHOP.getPieceType());
+        assertEquals(PieceType.BISHOP, Piece.BLACK_BISHOP.getPieceType());
+        assertEquals(PieceType.ROOK, Piece.WHITE_ROOK.getPieceType());
+        assertEquals(PieceType.ROOK, Piece.BLACK_ROOK.getPieceType());
+        assertEquals(PieceType.QUEEN, Piece.WHITE_QUEEN.getPieceType());
+        assertEquals(PieceType.QUEEN, Piece.BLACK_QUEEN.getPieceType());
+        assertEquals(PieceType.KING, Piece.WHITE_KING.getPieceType());
+        assertEquals(PieceType.KING, Piece.BLACK_KING.getPieceType());
+        assertNull(Piece.NONE.getPieceType());
+    }
+
+    @Test
+    public void getPieceSide() {
+        assertEquals(Side.WHITE, Piece.WHITE_PAWN.getPieceSide());
+        assertEquals(Side.BLACK, Piece.BLACK_PAWN.getPieceSide());
+        assertEquals(Side.WHITE, Piece.WHITE_KNIGHT.getPieceSide());
+        assertEquals(Side.BLACK, Piece.BLACK_KNIGHT.getPieceSide());
+        assertEquals(Side.WHITE, Piece.WHITE_BISHOP.getPieceSide());
+        assertEquals(Side.BLACK, Piece.BLACK_BISHOP.getPieceSide());
+        assertEquals(Side.WHITE, Piece.WHITE_ROOK.getPieceSide());
+        assertEquals(Side.BLACK, Piece.BLACK_ROOK.getPieceSide());
+        assertEquals(Side.WHITE, Piece.WHITE_QUEEN.getPieceSide());
+        assertEquals(Side.BLACK, Piece.BLACK_QUEEN.getPieceSide());
+        assertEquals(Side.WHITE, Piece.WHITE_KING.getPieceSide());
+        assertEquals(Side.BLACK, Piece.BLACK_KING.getPieceSide());
+        assertNull(Piece.NONE.getPieceSide());
+    }
+
+    @Test
+    public void make() {
+        assertEquals(Piece.WHITE_PAWN, Piece.make(Side.WHITE, PieceType.PAWN));
+        assertEquals(Piece.BLACK_PAWN, Piece.make(Side.BLACK, PieceType.PAWN));
+        assertEquals(Piece.WHITE_KNIGHT, Piece.make(Side.WHITE, PieceType.KNIGHT));
+        assertEquals(Piece.BLACK_KNIGHT, Piece.make(Side.BLACK, PieceType.KNIGHT));
+        assertEquals(Piece.WHITE_BISHOP, Piece.make(Side.WHITE, PieceType.BISHOP));
+        assertEquals(Piece.BLACK_BISHOP, Piece.make(Side.BLACK, PieceType.BISHOP));
+        assertEquals(Piece.WHITE_ROOK, Piece.make(Side.WHITE, PieceType.ROOK));
+        assertEquals(Piece.BLACK_ROOK, Piece.make(Side.BLACK, PieceType.ROOK));
+        assertEquals(Piece.WHITE_QUEEN, Piece.make(Side.WHITE, PieceType.QUEEN));
+        assertEquals(Piece.BLACK_QUEEN, Piece.make(Side.BLACK, PieceType.QUEEN));
+        assertEquals(Piece.WHITE_KING, Piece.make(Side.WHITE, PieceType.KING));
+        assertEquals(Piece.BLACK_KING, Piece.make(Side.BLACK, PieceType.KING));
+        assertEquals(Piece.NONE, Piece.make(Side.WHITE, PieceType.NONE));
+        assertEquals(Piece.NONE, Piece.make(Side.BLACK, PieceType.NONE));
+    }
+
+    @Test
+    public void fromValue() {
+        assertEquals(Piece.WHITE_PAWN, Piece.fromValue("WHITE_PAWN"));
+        assertEquals(Piece.BLACK_PAWN, Piece.fromValue("BLACK_PAWN"));
+        assertEquals(Piece.WHITE_KNIGHT, Piece.fromValue("WHITE_KNIGHT"));
+        assertEquals(Piece.BLACK_KNIGHT, Piece.fromValue("BLACK_KNIGHT"));
+        assertEquals(Piece.WHITE_BISHOP, Piece.fromValue("WHITE_BISHOP"));
+        assertEquals(Piece.BLACK_BISHOP, Piece.fromValue("BLACK_BISHOP"));
+        assertEquals(Piece.WHITE_ROOK, Piece.fromValue("WHITE_ROOK"));
+        assertEquals(Piece.BLACK_ROOK, Piece.fromValue("BLACK_ROOK"));
+        assertEquals(Piece.WHITE_QUEEN, Piece.fromValue("WHITE_QUEEN"));
+        assertEquals(Piece.BLACK_QUEEN, Piece.fromValue("BLACK_QUEEN"));
+        assertEquals(Piece.WHITE_KING, Piece.fromValue("WHITE_KING"));
+        assertEquals(Piece.BLACK_KING, Piece.fromValue("BLACK_KING"));
+        assertEquals(Piece.NONE, Piece.fromValue("NONE"));
+    }
+
+    @Test
+    public void value() {
+        assertEquals("WHITE_PAWN", Piece.WHITE_PAWN.value());
+        assertEquals("BLACK_PAWN", Piece.BLACK_PAWN.value());
+        assertEquals("WHITE_KNIGHT", Piece.WHITE_KNIGHT.value());
+        assertEquals("BLACK_KNIGHT", Piece.BLACK_KNIGHT.value());
+        assertEquals("WHITE_BISHOP", Piece.WHITE_BISHOP.value());
+        assertEquals("BLACK_BISHOP", Piece.BLACK_BISHOP.value());
+        assertEquals("WHITE_ROOK", Piece.WHITE_ROOK.value());
+        assertEquals("BLACK_ROOK", Piece.BLACK_ROOK.value());
+        assertEquals("WHITE_QUEEN", Piece.WHITE_QUEEN.value());
+        assertEquals("BLACK_QUEEN", Piece.BLACK_QUEEN.value());
+        assertEquals("WHITE_KING", Piece.WHITE_KING.value());
+        assertEquals("BLACK_KING", Piece.BLACK_KING.value());
+        assertEquals("NONE", Piece.NONE.value());
+    }
+}

--- a/src/test/java/com/github/bhlangonijr/chesslib/PieceTypeTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/PieceTypeTest.java
@@ -1,0 +1,29 @@
+package com.github.bhlangonijr.chesslib;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class PieceTypeTest {
+
+    @Test
+    public void fromSanSymbol() {
+        assertEquals(PieceType.PAWN, PieceType.fromSanSymbol(""));
+        assertEquals(PieceType.KNIGHT, PieceType.fromSanSymbol("N"));
+        assertEquals(PieceType.BISHOP, PieceType.fromSanSymbol("B"));
+        assertEquals(PieceType.ROOK, PieceType.fromSanSymbol("R"));
+        assertEquals(PieceType.QUEEN, PieceType.fromSanSymbol("Q"));
+        assertEquals(PieceType.KING, PieceType.fromSanSymbol("K"));
+        assertEquals(PieceType.NONE, PieceType.fromSanSymbol("NONE"));
+
+        try {
+            PieceType.fromSanSymbol("X");
+            fail("There should have been an exception");
+        } catch (Exception expected) {
+            assertTrue(expected instanceof IllegalArgumentException);
+            assertEquals("Unknown piece 'X'", expected.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
In my application I added a `Map<Piece,String>` which I used to get the FAN representation of each `Piece`, such as "♜" and "♙". Then I figured it would actually be a very useful feature if this library would just give me those symbols. I dug into the code and found that it already has a feature like that in the `MoveList` class, but it's just not public.

This pull request improves the `Piece` enum by adding several new methods: `getSanSymbol()`, `getFanSymbol()`, `getFenSymbol()`, and `fromFenSymbol(String)`. I think these additions also simplify the internal structure of the code, because you need fewer lookup tables in different classes. I was, in fact, able to mark some fields and methods in the `Constants` class as deprecated. I didn't dare to delete them, as someone may depend on them.