### PR TITLE
Include Opening property in Game's toPgn method

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/game/Game.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/game/Game.java
@@ -397,6 +397,9 @@ public class Game {
         if (getEco() != null && !getEco().equals("")) {
             sb.append(makeProp("ECO", getEco()));
         }
+        if (getOpening() != null && !getOpening().equals("")) {
+            sb.append(makeProp("Opening", getOpening()));
+        }
         if (getWhitePlayer().getElo() > 0) {
             sb.append(makeProp("WhiteElo", getWhitePlayer().getElo() + ""));
         }


### PR DESCRIPTION
Include the "Opening" property when converting a game to a PGN using toPgn().