### PR TITLE
Update TimeControl output "0" before "+"

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/game/TimeControl.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/game/TimeControl.java
@@ -230,7 +230,7 @@ public class TimeControl {
             s.append(getHalfMoves());
             s.append("/");
             s.append(getMilliseconds() / 1000);
-        } else if (getMilliseconds() > 0) {
+        } else if (getMilliseconds() >= 0) {
             s.append(getMilliseconds() / 1000);
         }
         if (getIncrement() > 0) {
@@ -257,7 +257,7 @@ public class TimeControl {
             s.append(" Moves / ");
             s.append(getMilliseconds() / 1000);
             s.append(" Sec");
-        } else if (getMilliseconds() > 0) {
+        } else if (getMilliseconds() >= 0) {
             s.append(getMilliseconds() / 1000 / 60);
             s.append(" Min");
         }


### PR DESCRIPTION
There are games where the time controls are "0+2", for example. Currently, TimeControl.java writes this out as "+2", which results in an error when reading the PGN back in. This fixes that issue.