### PR TITLE
Add support for onlyOutputEnPassantIfCapturable FENs

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -749,8 +749,7 @@ public class Board implements Cloneable, BoardEvent {
                 Square ep = Square.valueOf(s);
                 setEnPassant(ep);
                 setEnPassantTarget(findEnPassantTarget(ep, sideToMove));
-                if (!(squareAttackedByPieceType(getEnPassant(), getSideToMove(), PieceType.PAWN) != 0 &&
-                        verifyNotPinnedPiece(getSideToMove().flip(), getEnPassant(), getEnPassantTarget()))) {
+                if (!pawnCanBeCapturedEnPassant()) {
                     setEnPassantTarget(Square.NONE);
                 }
             } else {
@@ -795,6 +794,19 @@ public class Board implements Cloneable, BoardEvent {
      * @return board fen
      */
     public String getFen(boolean includeCounters) {
+        return getFen(includeCounters, false);
+    }
+
+    /**
+     * Generates the current board FEN representation
+     *
+     * @param includeCounters if true include halfMove and fullMove counters
+     * @param onlyOutputEnPassentIfCapturable if true, only output the en passant 
+     *   square if the pawn that just moved is able to be captured. If false, always
+     *   output the en passant square if a pawn just moved 2 squares.
+     * @return board fen
+     */
+    public String getFen(boolean includeCounters, boolean onlyOutputEnPassantIfCapturable) {
 
         StringBuffer fen = new StringBuffer();
         int count = 0;
@@ -866,7 +878,9 @@ public class Board implements Cloneable, BoardEvent {
             fen.append(" " + rights);
         }
 
-        if (Square.NONE.equals(getEnPassant())) {
+        if (Square.NONE.equals(getEnPassant()) 
+            || (onlyOutputEnPassantIfCapturable 
+                && !pawnCanBeCapturedEnPassant())) {
             fen.append(" -");
         } else {
             fen.append(" ");
@@ -1484,8 +1498,7 @@ public class Board implements Cloneable, BoardEvent {
         hash ^= getSideKey(getSideToMove());
 
         if (Square.NONE != getEnPassantTarget() &&
-                squareAttackedByPieceType(getEnPassant(), getSideToMove(), PieceType.PAWN) != 0 &&
-                verifyNotPinnedPiece(getSideToMove().flip(), getEnPassant(), getEnPassantTarget())) {
+                pawnCanBeCapturedEnPassant()) {
             hash ^= getEnPassantKey(getEnPassantTarget());
         }
         return hash;
@@ -1590,6 +1603,12 @@ public class Board implements Cloneable, BoardEvent {
 
     public void setIncrementalHashKey(long hashKey) {
         incrementalHashKey = hashKey;
+    }
+
+    private boolean pawnCanBeCapturedEnPassant() {
+        return 
+            squareAttackedByPieceType(getEnPassant(), getSideToMove(), PieceType.PAWN) != 0 
+            && verifyNotPinnedPiece(getSideToMove().flip(), getEnPassant(), getEnPassantTarget());
     }
 
     private boolean verifyNotPinnedPiece(Side side, Square enPassant, Square target) {

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -817,6 +817,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
                     return false;
                 }
             }
+            return true;
         }
         return false;
     }

--- a/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
@@ -127,6 +127,48 @@ public class BoardTest {
     }
 
     /**
+     * Test FEN formatting with `onlyOutputEnPassantIfCapturable` set to true,
+     * in a position where capturing en passant is possible.
+     */
+    @Test
+    public void testFENFormattingOnlyOutputEnPassantIfCapturable_EnPassantPossible() {
+        String fenWhereEnPassantPossible = "rnbqkbnr/1pp1pppp/p7/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3";
+        String expectedOutputFen = "rnbqkbnr/1pp1pppp/p7/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6";
+        Board board = new Board();
+        board.loadFromFen(fenWhereEnPassantPossible);
+        assertEquals(expectedOutputFen, board.getFen(false, true));
+    }
+
+    /**
+     * Test FEN formatting with `onlyOutputEnPassantIfCapturable` set to true,
+     * in a position where capturing en passant is not possible.
+     */
+    @Test
+    public void testFENFormattingOnlyOutputEnPassantIfCapturable_EnPassantNotPossible() {
+        String fenWhereEnPassantNotPossible = "rnbqkbnr/1pp1pppp/p7/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3";
+        String expectedOutputFen = "rnbqkbnr/1pp1pppp/p7/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq -";
+        Board board = new Board();
+        board.loadFromFen(fenWhereEnPassantNotPossible);
+        assertEquals(expectedOutputFen, board.getFen(false, true));
+    }
+
+    /**
+     * Test FEN formatting with `onlyOutputEnPassantIfCapturable` set to true,
+     * in a position where a 2-square pawn move just happened, but capturing en
+     * passant is not possible.
+     */
+    @Test
+    public void testFENFormattingOnlyOutputEnPassantIfCapturable_2SquarePawnMoveButEnPassantPossible() {
+        String fenWithTwoSquarePawnMoveNoEnPassantPossible = 
+            "rnbqkbnr/1pp1pppp/p7/3pP3/3P4/8/PPP2PPP/RNBQKBNR b KQkq d3 0 3";
+        String expectedOutputFen = "rnbqkbnr/1pp1pppp/p7/3pP3/3P4/8/PPP2PPP/RNBQKBNR b KQkq -";
+        Board board = new Board();
+        board.loadFromFen(fenWithTwoSquarePawnMoveNoEnPassantPossible);
+        assertEquals(expectedOutputFen, board.getFen(false, true));
+    }        
+        
+
+    /**
      * Test clone.
      */
     @Test


### PR DESCRIPTION
To use a FEN as a key to compare positions, the en passant field should only be set when the pawn can actually be taken. This allows transposed chess positions to have matching FENs, even if the last move in one of the positions was a 2-square pawn move without a possible en passant capture.

The FEN specification states that the en passant field should be set on every 2-square pawn move, but it is useful to be able to disable this for the aforementioned reason (using a FEN as a comparison key). Lichess, for example, seems to only set the en passant field when the pawn can be taken, so that they properly compare positions in their opening explorer.