### PR TITLE
Reduce visibility of protected static methods in MoveList

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -451,6 +451,8 @@ public class Board implements Cloneable, BoardEvent {
     /**
      * Reverts the effects of a piece previously moved. It restores the moved piece where it was and cancels any
      * possible promotion to another piece.
+     *
+     * @param move the move to undo
      */
     protected void undoMovePiece(Move move) {
         Square from = move.getFrom();
@@ -1288,6 +1290,7 @@ public class Board implements Cloneable, BoardEvent {
      * Checks if the squares of a move are consistent, that is, if the destination square is attacked by the piece
      * placed on the starting square.
      *
+     * @param move the move to check
      * @return {@code true} if the move is coherent
      */
     public boolean isAttackedBy(Move move) {
@@ -1384,6 +1387,7 @@ public class Board implements Cloneable, BoardEvent {
     /**
      * Verifies if the current position has been repeated at least <i>n</i> times, where <i>n</i> is provided in input.
      *
+     * @param n the number of repetitions to check in the position
      * @return {@code true} if the position has been repeated at least <i>n</i> times
      */
     public boolean isRepetition(int n) {

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -90,7 +90,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      *
      * @return the board representing the position after the moves are played
      */
-    protected static Board getBoard() {
+    private static Board getBoard() {
         return boardHolder.get();
     }
 
@@ -103,7 +103,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @throws MoveConversionException if the move conversion fails
      */
     // encode the move to SAN move and update thread local board
-    protected static String encodeToSan(final Board board, Move move) throws MoveConversionException {
+    private static String encodeToSan(final Board board, Move move) throws MoveConversionException {
         return encode(board, move, Piece::getSanSymbol);
     }
 
@@ -116,7 +116,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @throws MoveConversionException if the move conversion fails
      */
     // encode the move to FAN move and update thread local board
-    protected static String encodeToFan(final Board board, Move move) throws MoveConversionException {
+    private static String encodeToFan(final Board board, Move move) throws MoveConversionException {
         return encode(board, move, Piece::getFanSymbol);
     }
 
@@ -130,7 +130,7 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
      * @throws MoveConversionException if the move conversion fails
      */
     // encode the move to SAN/FAN move and update thread local board
-    protected static String encode(final Board board, Move move, Function<Piece, String> notation)
+    private static String encode(final Board board, Move move, Function<Piece, String> notation)
             throws MoveConversionException {
         StringBuilder san = new StringBuilder();
         Piece piece = board.getPiece(move.getFrom());

--- a/src/main/java/com/github/bhlangonijr/chesslib/pgn/PgnHolder.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/pgn/PgnHolder.java
@@ -115,6 +115,9 @@ public class PgnHolder {
     }
 
     /**
+     * Returns all the games stored in the holder.
+     *
+     * @return the games
      * @deprecated use {@link PgnHolder#getGames()} instead
      */
     @Deprecated


### PR DESCRIPTION
These methods are used only within the class and are defined as static. There is no need to keep them as `protected`, hence their visibility has been reduced to `private`.