### PR TITLE
Fixes UnicodePrinterTest (does'nt compile in java 8 and fails in 11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 

--- a/src/test/java/com/github/bhlangonijr/chesslib/unicode/UnicodePrinterTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/unicode/UnicodePrinterTest.java
@@ -24,7 +24,7 @@ public class UnicodePrinterTest {
         printer.print(board);
 
         String repr = baos.toString(StandardCharsets.UTF_8);
-        assertEquals("Should be a white rook", '\u2656', repr.charAt(0));
-        assertEquals("Should be a black rook", '\u265C', repr.charAt(63));
+        assertEquals("Should be a white rook at pos 0\n"+repr, '\u2656', repr.charAt(0));
+        assertEquals("Should be a black rook at pos 63\n"+repr, '\u265C', repr.split("\n")[7].charAt(7));
     }
 }


### PR DESCRIPTION
Here is a quick fix of UnicodePrinterTest that (as explained in [this issue](https://github.com/bhlangonijr/chesslib/issues/91) does not compile with java 8.
Moreover, the test is wrong. Due to the \n characters at the end of the lines, piece at position 63 in the result string is not a rook.
