### PR TITLE
If there is no piece on the source square inside `Board.isMoveLegal(move, fullValidation)` method, then return false instead of throwing exception

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -1204,7 +1204,7 @@ public class Board implements Cloneable, BoardEvent {
 
         if (fullValidation) {
             if (Piece.NONE.equals(fromPiece)) {
-                throw new RuntimeException("From piece cannot be null");
+                return false;
             }
 
             if (fromPiece.getPieceSide().equals(capturedPiece.getPieceSide())) {

--- a/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/BoardTest.java
@@ -829,5 +829,14 @@ public class BoardTest {
         assertEquals("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", board.getFen());
     }
 
+    @Test
+    public void testIsMoveLegalWithFullValidationFailureCase() {
+        Board board = new Board();
+        board.doMove(new Move(Square.E2, Square.E4));
+        board.doMove(new Move(Square.E7, Square.E5));
+
+        //* now there is no piece on E2 square
+        assertFalse(board.isMoveLegal(new Move(Square.E2, Square.E3), true));
+    }
 
 }


### PR DESCRIPTION
# Fix: Return false instead of throwing `RuntimeException` for invalid moves for one case

In the `Board.isMoveLegal(move, fullValidation)` method, if the `from` square of the given move is empty, a RuntimeException was being thrown. This PR change modifies the behavior to return false instead.

The expected behavior for the case should be to return false instead of throwing runtime exception, as the source (or from) square of the given move does not have any piece, hence making the move invalid. Throwing exception for this particular case is not expected from client side and handling runtime exception is problematic in client code. So returning `false` here should be a better option than throwing exception.