### PR TITLE
Update to commons-lang 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Dependency maven:org.apache.commons:commons-lang3:3.12.0 is vulnerable

Upgrade to 3.18.0

CVE-2025-48924,  Score: 5.3

Uncontrolled Recursion vulnerability in Apache Commons Lang. This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 before 3.18.0. The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a StackOverflowError could cause an application to stop. Users are recommended to upgrade to version 3.18.0, which fixes the issue.
 Mend Note: The description of this vulnerability differs from MITRE.

Read More: https://www.mend.io/vulnerability-database/CVE-2025-48924?utm_source=JetBrains