### PR TITLE
optimize PGN parsing process and improve perfomance

### DIFF
--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -892,7 +892,7 @@ public class Board implements Cloneable, BoardEvent {
      */
     public String getFen(boolean includeCounters, boolean onlyOutputEnPassantIfCapturable) {
 
-        StringBuffer fen = new StringBuffer();
+        StringBuilder fen = new StringBuilder();
         int emptySquares = 0;
         for (int i = 7; i >= 0; i--) {
             Rank r = Rank.allRanks[i];

--- a/src/main/java/com/github/bhlangonijr/chesslib/pgn/GameLoader.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/pgn/GameLoader.java
@@ -209,11 +209,12 @@ public class GameLoader {
     }
 
     private static boolean isEndGame(String line, PgnTempContainer container) {
-        if (!(line.endsWith("1-0") || line.endsWith("0-1") || line.endsWith("1/2-1/2") || line.endsWith("*")))
-            return false;
-
         updateCommentState(line, container);
-        return !container.commentOpened;
+        if (container.commentOpened) {
+            return false;
+        }
+        return line.endsWith("1-0") || line.endsWith("0-1")
+                || line.endsWith("1/2-1/2") || line.endsWith("*");
     }
 
     private static void updateCommentState(String line, PgnTempContainer container) {
@@ -221,7 +222,7 @@ public class GameLoader {
             char c = line.charAt(i);
             if (c == '{') {
                 container.commentOpened = true;
-            } else if (c == '}') {
+            } else if (c == '}' && container.commentOpened) {
                 container.commentOpened = false;
             }
         }

--- a/src/main/java/com/github/bhlangonijr/chesslib/pgn/GameLoader.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/pgn/GameLoader.java
@@ -69,7 +69,7 @@ public class GameLoader {
                     addProperty(line, container);
                 } else if (StringUtils.isNotEmpty(line)) {
                     addMoveText(line, container);
-                    if (isEndGame(line)) {
+                    if (isEndGame(line, container)) {
                         setMoveText(container.game, container.moveText);
                         return container.initGame ? container.game : null;
                     }
@@ -208,25 +208,23 @@ public class GameLoader {
         container.moveTextParsing = true;
     }
 
-    private static boolean isEndGame(String line) {
-        String stripped = stripBracketContent(line);
-        return stripped.endsWith("1-0") || stripped.endsWith("0-1") || stripped.endsWith("1/2-1/2") || stripped.endsWith("*");
+    private static boolean isEndGame(String line, PgnTempContainer container) {
+        if (!(line.endsWith("1-0") || line.endsWith("0-1") || line.endsWith("1/2-1/2") || line.endsWith("*")))
+            return false;
+
+        updateCommentState(line, container);
+        return !container.commentOpened;
     }
 
-    private static String stripBracketContent(String line) {
-        int depth = 0;
-        StringBuilder sb = new StringBuilder(line.length());
+    private static void updateCommentState(String line, PgnTempContainer container) {
         for (int i = 0; i < line.length(); i++) {
             char c = line.charAt(i);
             if (c == '{') {
-                depth++;
-            } else if (c == '}' && depth > 0) {
-                depth--;
-            } else if (depth == 0) {
-                sb.append(c);
+                container.commentOpened = true;
+            } else if (c == '}') {
+                container.commentOpened = false;
             }
         }
-        return sb.toString().trim();
     }
 
     private static class PgnTempContainer {
@@ -241,6 +239,7 @@ public class GameLoader {
         final StringBuilder moveText;
         boolean moveTextParsing;
         boolean initGame;
+        boolean commentOpened;
 
         PgnTempContainer() {
             this.event = new Event();

--- a/src/main/java/com/github/bhlangonijr/chesslib/pgn/PgnProperty.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/pgn/PgnProperty.java
@@ -60,13 +60,16 @@ public class PgnProperty {
      */
     public static PgnProperty parsePgnProperty(String line) {
         try {
+            int nameStart = 1;
+            int nameEnd = line.indexOf(' ', 1);
 
-            String l = line.replace("[", StringUtils.EMPTY);
-            l = l.replace("]", StringUtils.EMPTY);
-            l = l.replace("\"", StringUtils.EMPTY);
+            int valueStart = line.indexOf('\"', nameEnd) + 1;
+            int valueEnd = line.lastIndexOf('\"');
 
-            return new PgnProperty(StringUtil.beforeSequence(l, StringUtils.SPACE),
-                    StringUtil.afterSequence(l, StringUtils.SPACE));
+            return new PgnProperty(
+                    line.substring(nameStart, nameEnd),
+                    line.substring(valueStart, valueEnd)
+            );
         } catch (Exception e) {
             // do nothing
         }

--- a/src/main/java/com/github/bhlangonijr/chesslib/pgn/PgnProperty.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/pgn/PgnProperty.java
@@ -15,7 +15,6 @@ public class PgnProperty {
      */
     public final static String UTF8_BOM = "\uFEFF";
 
-    private final static Pattern propertyPattern = Pattern.compile("\\[.* \".*\"\\]");
     /**
      * The name of the PGN property.
      */
@@ -49,7 +48,7 @@ public class PgnProperty {
      * @return {@code true} if the line is a PGN property
      */
     public static boolean isProperty(String line) {
-        return propertyPattern.matcher(line).matches();
+        return line.startsWith("[") && line.endsWith("]") && (line.indexOf('\"') != line.lastIndexOf('\"'));
     }
 
     /**

--- a/src/test/java/com/github/bhlangonijr/chesslib/PgnHolderTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/PgnHolderTest.java
@@ -655,4 +655,47 @@ public class PgnHolderTest {
         assertEquals(6, game.getHalfMoves().size());
     }
 
+    @Test
+    public void testMultiLineCommentSpanningResultToken() {
+        List<String> lines = Arrays.asList(
+                "[Event \"Test\"]",
+                "[Site \"Test\"]",
+                "[Date \"2024.01.01\"]",
+                "[Round \"1\"]",
+                "[White \"Player1\"]",
+                "[Black \"Player2\"]",
+                "[Result \"0-1\"]",
+                "",
+                "1.f3 e5 { Annotator notes:",
+                "the historical score here was 0-1",
+                "} 2.g3 d5 3.g4 Qh4# 0-1",
+                ""
+        );
+        Game game = GameLoader.loadNextGame(lines.iterator());
+        assertEquals("0-1", game.getResult().getDescription());
+        assertEquals(6, game.getHalfMoves().size());
+    }
+
+    @Test
+    public void testMultiLineCommentWithoutBracesOnInteriorLine() {
+        List<String> lines = Arrays.asList(
+                "[Event \"Test\"]",
+                "[Site \"Test\"]",
+                "[Date \"2024.01.01\"]",
+                "[Round \"1\"]",
+                "[White \"Player1\"]",
+                "[Black \"Player2\"]",
+                "[Result \"1-0\"]",
+                "",
+                "1.e4 e5 { comment opens here",
+                "interior line with no braces but ending in 1-0",
+                "still inside comment, score was 1/2-1/2",
+                "closing now } 2.Nf3 Nc6 3.Bb5 a6 1-0",
+                ""
+        );
+        Game game = GameLoader.loadNextGame(lines.iterator());
+        assertEquals("1-0", game.getResult().getDescription());
+        assertEquals(6, game.getHalfMoves().size());
+    }
+
 }


### PR DESCRIPTION
[perf: replace StringBuffer with StringBuilder]
- It can be a non-thread safe, but it was a StringBuffer
- All mutable strings in this project are StringBuilder, I think you didn't do it on purpose

[perf: reduce String objects in parsePgnProperty]
- It had 5 subStrings before, but I reduced 3 of it with using indexOf

[perf: replace pattern matcher with boolean expressions]
- Pattern matching was too heavy to filter isProperty, so i replace it with 4 boolean expressions
- It's faster especially parsing moveText, they could be filtered with the first boolean expression

[perf: replace int depth with boolean value in isEndGame]
- I added a boolean field to check whether pgn line is in a comment
- It returns true when the comment is closed and ends with a result

I passed every test cases.

PS . Always thanks for your library!! 