### PR TITLE
feat: Add complete Chess960 (Fischer Random) support with UCI convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 *.iml
 .DS_Store
+bin/
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Chesslib
-### A Lightweight, High-Performance Java Chess Library
+### A Lightweight, High-Performance Java Chess Library — Chess960 Fork
 
-[![JitPack](https://jitpack.io/v/bhlangonijr/chesslib.svg)](https://jitpack.io/#bhlangonijr/chesslib)
-![Build Status](https://github.com/bhlangonijr/chesslib/actions/workflows/maven.yml/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 **Chesslib** is a clean, efficient Java library for legal move generation, position validation, and PGN/FEN parsing. It is designed for developers who need a robust engine backbone with high-speed performance and a low memory footprint.
 
-Whether you are building a chess UI, a server-side validator, or a full-strength engine, Chesslib provides the tools you need.
+This is a fork of [bhlangonijr/chesslib](https://github.com/bhlangonijr/chesslib) v1.3.6 that adds full **Chess960 (Fischer Random)** castling support.
 
 ---
 
@@ -19,27 +17,17 @@ Add the JitPack repository and the dependency to your project build file.
 
 #### Maven
 ```xml
-<repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>[https://jitpack.io](https://jitpack.io)</url>
-    </repository>
-</repositories>
-
 <dependency>
-    <groupId>com.github.bhlangonijr</groupId>
+    <groupId>tech.solusoft.chess</groupId>
     <artifactId>chesslib</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.6-chess960</version>
 </dependency>
-
 ```
 
 #### Gradle
 
 ```groovy
-repositories { maven { url '[https://jitpack.io](https://jitpack.io)' } }
-dependencies { implementation 'com.github.bhlangonijr:chesslib:1.3.6' }
-
+dependencies { implementation 'tech.solusoft.chess:chesslib:1.3.6-chess960' }
 ```
 
 ### Hello World: Making Moves
@@ -192,6 +180,68 @@ board.addEventListener(BoardEventType.ON_MOVE, event -> {
 
 * **`board.getZobristKey()`**: Returns the Zobrist hash (long) for rapid transposition table lookups.
 * **`board.strictEquals(otherBoard)`**: Compares position **AND** move history (crucial for 3-fold repetition detection).
+
+---
+
+## ♛ Chess960 (Fischer Random) Support
+
+This fork adds full Chess960 castling support to chesslib. All 960 starting positions are handled correctly, including move generation, validation, execution, undo, SAN parsing, and FEN round-trip.
+
+### Detection
+
+Chess960 is detected automatically when loading a FEN:
+
+- **Shredder-FEN**: castling field uses file letters (`AHah`, `BFbf`, etc.) instead of `KQkq`
+- **KQkq with non-standard king**: king not on e-file but castling rights present (e.g. Lichess format)
+
+You can also force Chess960 mode explicitly — useful when the PGN has `[Variant "Chess960"]` but the FEN uses standard `KQkq` notation with the king on the e-file:
+
+```java
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1", true);
+```
+
+### Querying
+
+```java
+boolean isChess960 = board.getContext().getVariationType() == VariationType.CHESS960;
+```
+
+### Castling
+
+Chess960 castling follows the standard rules: king always ends on the g-file (O-O) or c-file (O-O-O), rook always ends on the f-file (O-O) or d-file (O-O-O). The `GameContext` is configured dynamically based on the actual king and rook positions found in the FEN.
+
+```java
+Board board = new Board();
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+// SAN parsing works
+MoveList moves = new MoveList(board.getFen());
+moves.loadFromSan("e4 e5 b3 Ng6 g3 O-O");
+
+// Move generation includes castling
+board.legalMoves(); // contains the O-O move for black
+
+// FEN export uses Shredder-FEN for Chess960
+board.getFen(); // castling field will be "EHeh" instead of "KQkq"
+```
+
+### Edge cases handled
+
+- King already on destination square (e.g. king on g1 doing O-O → king stays, rook moves)
+- King and rook adjacent or swapping squares
+- Rook between king start and king destination
+- Correct undo/redo of all Chess960 castling configurations
+- Castle rights properly lost when rook or king moves
+
+### Files changed (vs upstream 1.3.6)
+
+| File | Change |
+|------|--------|
+| `GameContext` | Added `loadChess960()` to configure castling dynamically from piece positions |
+| `Board` | FEN parsing detects Chess960; `loadFromFen(fen, chess960)` overload; `doMove`/`isMoveLegal` handle Chess960 castling; `getFen` exports Shredder-FEN |
+| `MoveGenerator` | `generateCastleMoves` excludes king/rook from occupancy check for Chess960 |
+| `MoveList` | `encode` uses `context.isCastleMove()` instead of file-delta for castle detection |
+| `MoveBackup` | `restore` handles Chess960 castle undo |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -233,14 +233,39 @@ board.getFen(); // castling field will be "EHeh" instead of "KQkq"
 - Correct undo/redo of all Chess960 castling configurations
 - Castle rights properly lost when rook or king moves
 
+### UCI notation
+
+Internally, chesslib represents a castling move as king → final destination (e.g. `G1→G1` for O-O when king is already on g1). This differs from the official UCI Chess960 convention, where castling is encoded as king → rook square (e.g. `g1h1`).
+
+To bridge this gap, use `board.toUci()` and `board.fromUci()` instead of `move.toString()` or `new Move(uci, side)` when working with UCI strings:
+
+```java
+Board board = new Board();
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+// Convert a Move to UCI (king→rook for Chess960 castling)
+Move oo = board.getContext().getoo(Side.WHITE);
+board.toUci(oo);    // "g1h1" (UCI Chess960 convention)
+oo.toString();       // "g1g1" (internal representation — do NOT use for UCI)
+
+// Parse a UCI string into a Move (recognizes king→rook as castling)
+Move parsed = board.fromUci("g1h1");  // returns the O-O castle move
+
+// MoveList.loadFromText also handles Chess960 UCI correctly
+MoveList moves = new MoveList(board.getFen());
+moves.loadFromText("e2e4 e7e5 b2b3 f8g6 g2g3 g8h8");  // g8h8 = Black O-O
+```
+
+In standard chess, `toUci()` and `fromUci()` behave identically to `move.toString()` and `new Move(uci, side)` — no change needed for existing code.
+
 ### Files changed (vs upstream 1.3.6)
 
 | File | Change |
 |------|--------|
 | `GameContext` | Added `loadChess960()` to configure castling dynamically from piece positions |
-| `Board` | FEN parsing detects Chess960; `loadFromFen(fen, chess960)` overload; `doMove`/`isMoveLegal` handle Chess960 castling; `getFen` exports Shredder-FEN |
+| `Board` | FEN parsing detects Chess960; `loadFromFen(fen, chess960)` overload; `doMove`/`isMoveLegal` handle Chess960 castling; `getFen` exports Shredder-FEN; `toUci()`/`fromUci()` for UCI Chess960 convention |
 | `MoveGenerator` | `generateCastleMoves` excludes king/rook from occupancy check for Chess960 |
-| `MoveList` | `encode` uses `context.isCastleMove()` instead of file-delta for castle detection |
+| `MoveList` | `encode` uses `context.isCastleMove()` instead of file-delta for castle detection; `loadFromText` uses `board.fromUci()` |
 | `MoveBackup` | `restore` handles Chess960 castle undo |
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Chesslib
-### A Lightweight, High-Performance Java Chess Library
+### A Lightweight, High-Performance Java Chess Library — Chess960 Fork
 
-[![JitPack](https://jitpack.io/v/bhlangonijr/chesslib.svg)](https://jitpack.io/#bhlangonijr/chesslib)
-![Build Status](https://github.com/bhlangonijr/chesslib/actions/workflows/maven.yml/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 **Chesslib** is a clean, efficient Java library for legal move generation, position validation, and PGN/FEN parsing. It is designed for developers who need a robust engine backbone with high-speed performance and a low memory footprint.
 
-Whether you are building a chess UI, a server-side validator, or a full-strength engine, Chesslib provides the tools you need.
+This is a fork of [bhlangonijr/chesslib](https://github.com/bhlangonijr/chesslib) v1.3.6 that adds full **Chess960 (Fischer Random)** castling support.
 
 ---
 
@@ -19,27 +17,17 @@ Add the JitPack repository and the dependency to your project build file.
 
 #### Maven
 ```xml
-<repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-
 <dependency>
-    <groupId>com.github.bhlangonijr</groupId>
+    <groupId>tech.solusoft.chess</groupId>
     <artifactId>chesslib</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.6-chess960</version>
 </dependency>
-
 ```
 
 #### Gradle
 
 ```groovy
-repositories { maven { url 'https://jitpack.io' } }
-dependencies { implementation 'com.github.bhlangonijr:chesslib:1.3.7' }
-
+dependencies { implementation 'tech.solusoft.chess:chesslib:1.3.6-chess960' }
 ```
 
 ### Hello World: Making Moves
@@ -192,6 +180,68 @@ board.addEventListener(BoardEventType.ON_MOVE, event -> {
 
 * **`board.getZobristKey()`**: Returns the Zobrist hash (long) for rapid transposition table lookups.
 * **`board.strictEquals(otherBoard)`**: Compares position **AND** move history (crucial for 3-fold repetition detection).
+
+---
+
+## ♛ Chess960 (Fischer Random) Support
+
+This fork adds full Chess960 castling support to chesslib. All 960 starting positions are handled correctly, including move generation, validation, execution, undo, SAN parsing, and FEN round-trip.
+
+### Detection
+
+Chess960 is detected automatically when loading a FEN:
+
+- **Shredder-FEN**: castling field uses file letters (`AHah`, `BFbf`, etc.) instead of `KQkq`
+- **KQkq with non-standard king**: king not on e-file but castling rights present (e.g. Lichess format)
+
+You can also force Chess960 mode explicitly — useful when the PGN has `[Variant "Chess960"]` but the FEN uses standard `KQkq` notation with the king on the e-file:
+
+```java
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1", true);
+```
+
+### Querying
+
+```java
+boolean isChess960 = board.getContext().getVariationType() == VariationType.CHESS960;
+```
+
+### Castling
+
+Chess960 castling follows the standard rules: king always ends on the g-file (O-O) or c-file (O-O-O), rook always ends on the f-file (O-O) or d-file (O-O-O). The `GameContext` is configured dynamically based on the actual king and rook positions found in the FEN.
+
+```java
+Board board = new Board();
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+// SAN parsing works
+MoveList moves = new MoveList(board.getFen());
+moves.loadFromSan("e4 e5 b3 Ng6 g3 O-O");
+
+// Move generation includes castling
+board.legalMoves(); // contains the O-O move for black
+
+// FEN export uses Shredder-FEN for Chess960
+board.getFen(); // castling field will be "EHeh" instead of "KQkq"
+```
+
+### Edge cases handled
+
+- King already on destination square (e.g. king on g1 doing O-O → king stays, rook moves)
+- King and rook adjacent or swapping squares
+- Rook between king start and king destination
+- Correct undo/redo of all Chess960 castling configurations
+- Castle rights properly lost when rook or king moves
+
+### Files changed (vs upstream 1.3.6)
+
+| File | Change |
+|------|--------|
+| `GameContext` | Added `loadChess960()` to configure castling dynamically from piece positions |
+| `Board` | FEN parsing detects Chess960; `loadFromFen(fen, chess960)` overload; `doMove`/`isMoveLegal` handle Chess960 castling; `getFen` exports Shredder-FEN |
+| `MoveGenerator` | `generateCastleMoves` excludes king/rook from occupancy check for Chess960 |
+| `MoveList` | `encode` uses `context.isCastleMove()` instead of file-delta for castle detection |
+| `MoveBackup` | `restore` handles Chess960 castle undo |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Chesslib
-### A Lightweight, High-Performance Java Chess Library — Chess960 Fork
+### A Lightweight, High-Performance Java Chess Library
 
+[![JitPack](https://jitpack.io/v/bhlangonijr/chesslib.svg)](https://jitpack.io/#bhlangonijr/chesslib)
+![Build Status](https://github.com/bhlangonijr/chesslib/actions/workflows/maven.yml/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 **Chesslib** is a clean, efficient Java library for legal move generation, position validation, and PGN/FEN parsing. It is designed for developers who need a robust engine backbone with high-speed performance and a low memory footprint.
 
-This is a fork of [bhlangonijr/chesslib](https://github.com/bhlangonijr/chesslib) v1.3.6 that adds full **Chess960 (Fischer Random)** castling support.
+Whether you are building a chess UI, a server-side validator, or a full-strength engine, Chesslib provides the tools you need.
 
 ---
 
@@ -17,17 +19,27 @@ Add the JitPack repository and the dependency to your project build file.
 
 #### Maven
 ```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+
 <dependency>
-    <groupId>tech.solusoft.chess</groupId>
+    <groupId>com.github.bhlangonijr</groupId>
     <artifactId>chesslib</artifactId>
-    <version>1.3.6-chess960</version>
+    <version>1.3.7</version>
 </dependency>
+
 ```
 
 #### Gradle
 
 ```groovy
-dependencies { implementation 'tech.solusoft.chess:chesslib:1.3.6-chess960' }
+repositories { maven { url 'https://jitpack.io' } }
+dependencies { implementation 'com.github.bhlangonijr:chesslib:1.3.7' }
+
 ```
 
 ### Hello World: Making Moves
@@ -183,93 +195,6 @@ board.addEventListener(BoardEventType.ON_MOVE, event -> {
 
 ---
 
-## ♛ Chess960 (Fischer Random) Support
-
-This fork adds full Chess960 castling support to chesslib. All 960 starting positions are handled correctly, including move generation, validation, execution, undo, SAN parsing, and FEN round-trip.
-
-### Detection
-
-Chess960 is detected automatically when loading a FEN:
-
-- **Shredder-FEN**: castling field uses file letters (`AHah`, `BFbf`, etc.) instead of `KQkq`
-- **KQkq with non-standard king**: king not on e-file but castling rights present (e.g. Lichess format)
-
-You can also force Chess960 mode explicitly — useful when the PGN has `[Variant "Chess960"]` but the FEN uses standard `KQkq` notation with the king on the e-file:
-
-```java
-board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1", true);
-```
-
-### Querying
-
-```java
-boolean isChess960 = board.getContext().getVariationType() == VariationType.CHESS960;
-```
-
-### Castling
-
-Chess960 castling follows the standard rules: king always ends on the g-file (O-O) or c-file (O-O-O), rook always ends on the f-file (O-O) or d-file (O-O-O). The `GameContext` is configured dynamically based on the actual king and rook positions found in the FEN.
-
-```java
-Board board = new Board();
-board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
-
-// SAN parsing works
-MoveList moves = new MoveList(board.getFen());
-moves.loadFromSan("e4 e5 b3 Ng6 g3 O-O");
-
-// Move generation includes castling
-board.legalMoves(); // contains the O-O move for black
-
-// FEN export uses Shredder-FEN for Chess960
-board.getFen(); // castling field will be "EHeh" instead of "KQkq"
-```
-
-### Edge cases handled
-
-- King already on destination square (e.g. king on g1 doing O-O → king stays, rook moves)
-- King and rook adjacent or swapping squares
-- Rook between king start and king destination
-- Correct undo/redo of all Chess960 castling configurations
-- Castle rights properly lost when rook or king moves
-
-### UCI notation
-
-Internally, chesslib represents a castling move as king → final destination (e.g. `G1→G1` for O-O when king is already on g1). This differs from the official UCI Chess960 convention, where castling is encoded as king → rook square (e.g. `g1h1`).
-
-To bridge this gap, use `board.toUci()` and `board.fromUci()` instead of `move.toString()` or `new Move(uci, side)` when working with UCI strings:
-
-```java
-Board board = new Board();
-board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
-
-// Convert a Move to UCI (king→rook for Chess960 castling)
-Move oo = board.getContext().getoo(Side.WHITE);
-board.toUci(oo);    // "g1h1" (UCI Chess960 convention)
-oo.toString();       // "g1g1" (internal representation — do NOT use for UCI)
-
-// Parse a UCI string into a Move (recognizes king→rook as castling)
-Move parsed = board.fromUci("g1h1");  // returns the O-O castle move
-
-// MoveList.loadFromText also handles Chess960 UCI correctly
-MoveList moves = new MoveList(board.getFen());
-moves.loadFromText("e2e4 e7e5 b2b3 f8g6 g2g3 g8h8");  // g8h8 = Black O-O
-```
-
-In standard chess, `toUci()` and `fromUci()` behave identically to `move.toString()` and `new Move(uci, side)` — no change needed for existing code.
-
-### Files changed (vs upstream 1.3.6)
-
-| File | Change |
-|------|--------|
-| `GameContext` | Added `loadChess960()` to configure castling dynamically from piece positions |
-| `Board` | FEN parsing detects Chess960; `loadFromFen(fen, chess960)` overload; `doMove`/`isMoveLegal` handle Chess960 castling; `getFen` exports Shredder-FEN; `toUci()`/`fromUci()` for UCI Chess960 convention |
-| `MoveGenerator` | `generateCastleMoves` excludes king/rook from occupancy check for Chess960 |
-| `MoveList` | `encode` uses `context.isCastleMove()` instead of file-delta for castle detection; `loadFromText` uses `board.fromUci()` |
-| `MoveBackup` | `restore` handles Chess960 castle undo |
-
----
-
 ## Performance & Testing
 
 ### Perft (Performance Test)
@@ -291,6 +216,36 @@ We welcome pull requests! Please ensure all tests pass before submitting.
 
 * **Bug Reports:** Please provide a minimal reproduction case (FEN + Move).
 * **Feature Requests:** Open an issue to discuss.
+
+## ♛ Chess960 (Fischer Random) Support
+
+Full Chess960 castling support is included. All 960 starting positions are handled correctly, including move generation, validation, execution, undo, SAN parsing, and FEN round-trip.
+
+### Detection
+
+Chess960 is detected automatically when loading a FEN with Shredder-FEN castling notation or non-standard king position. You can also force it explicitly:
+
+```java
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1", true);
+```
+
+### Castling
+
+King always ends on g-file (O-O) or c-file (O-O-O). Rook always ends on f-file (O-O) or d-file (O-O-O). Edge cases handled: king already on destination, king/rook adjacent, rook between king start/dest.
+
+### UCI Notation
+
+Use `board.toUci(move)` and `board.fromUci(uciString)` for Chess960 UCI convention (king-to-rook encoding):
+
+```java
+Board board = new Board();
+board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+Move oo = board.getContext().getoo(Side.WHITE);
+board.toUci(oo);    // "g1h1" (king→rook)
+Move parsed = board.fromUci("g1h1");  // returns the O-O castle move
+```
+
+In standard chess, `toUci()` and `fromUci()` behave identically to `move.toString()` and `new Move(uci, side)`.
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.bhlangonijr.chesslib</groupId>
+    <groupId>tech.solusoft.chess</groupId>
     <artifactId>chesslib</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.6-chess960</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>tech.solusoft.chess</groupId>
+    <groupId>com.github.bhlangonijr.chesslib</groupId>
     <artifactId>chesslib</artifactId>
-    <version>1.3.6-chess960</version>
+    <version>1.3.7</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.bhlangonijr.chesslib</groupId>
+    <groupId>tech.solusoft.chess</groupId>
     <artifactId>chesslib</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.6-chess960</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -1787,6 +1787,66 @@ public class Board implements Cloneable, BoardEvent {
     }
 
     /**
+     * Converts a move to its UCI string representation. In Chess960, castling is encoded as
+     * king-to-rook (e.g. "e1h1" for O-O when rook is on h1), following the official UCI Chess960 convention.
+     * In standard chess, castling is encoded as king-to-destination (e.g. "e1g1" for O-O).
+     *
+     * @param move the move to convert
+     * @return the UCI string representation of the move
+     */
+    public String toUci(Move move) {
+        if (context.getVariationType() == VariationType.CHESS960 && context.isCastleMove(move)) {
+            Side side = getSideToMove();
+            Move rookMove = context.isKingSideCastle(move)
+                    ? context.getRookoo(side)
+                    : context.getRookooo(side);
+            if (rookMove != null) {
+                return move.getFrom().toString().toLowerCase() + rookMove.getFrom().toString().toLowerCase();
+            }
+        }
+        String uci = move.getFrom().toString().toLowerCase() + move.getTo().toString().toLowerCase();
+        if (move.getPromotion() != Piece.NONE) {
+            uci += move.getPromotion().getFenSymbol().toLowerCase();
+        }
+        return uci;
+    }
+
+    /**
+     * Parses a UCI string into a Move, handling Chess960 castling notation. In Chess960, castling is
+     * encoded as king-to-rook (e.g. "e1h1"), which is converted to the internal king-to-destination format.
+     *
+     * @param uci the UCI string to parse (e.g. "e2e4", "e1h1" for Chess960 castling)
+     * @return the parsed Move
+     */
+    public Move fromUci(String uci) {
+        if (uci.length() >= 4 && context.getVariationType() == VariationType.CHESS960) {
+            Square from = Square.valueOf(uci.substring(0, 2).toUpperCase());
+            Square to = Square.valueOf(uci.substring(2, 4).toUpperCase());
+            Piece fromPiece = getPiece(from);
+            Piece toPiece = getPiece(to);
+            // King moving to own rook = castling in UCI Chess960
+            if (fromPiece.getPieceType() == PieceType.KING && toPiece.getPieceType() == PieceType.ROOK
+                    && fromPiece.getPieceSide() == toPiece.getPieceSide()) {
+                int fromFile = from.getFile().ordinal();
+                int toFile = to.getFile().ordinal();
+                return toFile > fromFile
+                        ? context.getoo(getSideToMove())
+                        : context.getooo(getSideToMove());
+            }
+        }
+        Piece promotion = Piece.NONE;
+        if (uci.length() == 5) {
+            promotion = Piece.fromFenSymbol(
+                    getSideToMove() == Side.WHITE
+                            ? String.valueOf(uci.charAt(4)).toUpperCase()
+                            : String.valueOf(uci.charAt(4)).toLowerCase());
+        }
+        Square from = Square.valueOf(uci.substring(0, 2).toUpperCase());
+        Square to = Square.valueOf(uci.substring(2, 4).toUpperCase());
+        return new Move(from, to, promotion);
+    }
+
+    /**
      * Returns the list of all possible pseudo-legal moves for the current position.
      * <p>
      * A move is considered pseudo-legal when it is legal according to the standard rules of chess piece movements, but

--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -16,9 +16,6 @@
 
 package com.github.bhlangonijr.chesslib;
 
-import static com.github.bhlangonijr.chesslib.Bitboard.extractLsb;
-import static com.github.bhlangonijr.chesslib.Constants.emptyMove;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,12 +26,16 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
+import org.apache.commons.lang3.StringUtils;
+
+import static com.github.bhlangonijr.chesslib.Bitboard.extractLsb;
+import static com.github.bhlangonijr.chesslib.Constants.emptyMove;
 import com.github.bhlangonijr.chesslib.game.GameContext;
+import com.github.bhlangonijr.chesslib.game.VariationType;
 import com.github.bhlangonijr.chesslib.move.Move;
 import com.github.bhlangonijr.chesslib.move.MoveGenerator;
 import com.github.bhlangonijr.chesslib.move.MoveList;
 import com.github.bhlangonijr.chesslib.util.XorShiftRandom;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * The definition of a chessboard position and its status. It exposes methods to manipulate the board, evolve the
@@ -233,7 +234,23 @@ public class Board implements Cloneable, BoardEvent {
                     CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE :
                             CastleRight.QUEEN_SIDE;
                     Move rookMove = context.getRookCastleMove(side, c);
-                    movePiece(rookMove, backupMove);
+                    if (context.getVariationType() == VariationType.CHESS960) {
+                        // Chess960: manually handle piece placement to avoid capture issues
+                        Piece king = getPiece(move.getFrom());
+                        Piece rook = getPiece(rookMove.getFrom());
+                        unsetPiece(king, move.getFrom());
+                        if (!rookMove.getFrom().equals(move.getFrom())) {
+                            unsetPiece(rook, rookMove.getFrom());
+                        }
+                        setPiece(rook, rookMove.getTo());
+                        if (!move.getTo().equals(rookMove.getTo())) {
+                            setPiece(king, move.getTo());
+                        } else {
+                            setPiece(king, move.getTo());
+                        }
+                    } else {
+                        movePiece(rookMove, backupMove);
+                    }
                 } else {
                     return false;
                 }
@@ -268,7 +285,13 @@ public class Board implements Cloneable, BoardEvent {
             }
         }
 
-        Piece capturedPiece = movePiece(move, backupMove);
+        Piece capturedPiece;
+        if (isCastle && context.getVariationType() == VariationType.CHESS960) {
+            // Chess960: king and rook already placed above, no capture possible
+            capturedPiece = Piece.NONE;
+        } else {
+            capturedPiece = movePiece(move, backupMove);
+        }
 
         if (PieceType.ROOK == capturedPiece.getPieceType()) {
             final Move oo = context.getRookoo(side.flip());
@@ -769,6 +792,19 @@ public class Board implements Cloneable, BoardEvent {
      * @param fen the FEN string representing the chess position to load
      */
     public void loadFromFen(String fen) {
+        loadFromFen(fen, false);
+    }
+
+    /**
+     * Loads a specific chess position from a valid Forsyth-Edwards Notation (FEN) string. When {@code chess960} is
+     * {@code true}, the position is treated as Chess960 regardless of the castling notation — this is useful when
+     * the PGN tag {@code [Variant "Chess960"]} is present but the FEN uses standard {@code KQkq} notation with
+     * the king on the e-file.
+     *
+     * @param fen     the FEN string representing the chess position to load
+     * @param chess960 if {@code true}, force Chess960 mode
+     */
+    public void loadFromFen(String fen, boolean chess960) {
         clear();
         String squares = fen.substring(0, fen.indexOf(' '));
         String state = fen.substring(fen.indexOf(' ') + 1);
@@ -793,27 +829,177 @@ public class Board implements Cloneable, BoardEvent {
 
         sideToMove = state.toLowerCase().charAt(0) == 'w' ? Side.WHITE : Side.BLACK;
 
-        if (state.contains("KQ")) {
-            castleRight.put(Side.WHITE, CastleRight.KING_AND_QUEEN_SIDE);
-        } else if (state.contains("K")) {
-            castleRight.put(Side.WHITE, CastleRight.KING_SIDE);
-        } else if (state.contains("Q")) {
-            castleRight.put(Side.WHITE, CastleRight.QUEEN_SIDE);
-        } else {
-            castleRight.put(Side.WHITE, CastleRight.NONE);
-        }
-
-        if (state.contains("kq")) {
-            castleRight.put(Side.BLACK, CastleRight.KING_AND_QUEEN_SIDE);
-        } else if (state.contains("k")) {
-            castleRight.put(Side.BLACK, CastleRight.KING_SIDE);
-        } else if (state.contains("q")) {
-            castleRight.put(Side.BLACK, CastleRight.QUEEN_SIDE);
-        } else {
-            castleRight.put(Side.BLACK, CastleRight.NONE);
-        }
-
         String[] flags = state.split(StringUtils.SPACE);
+        String castlingField = flags.length >= 2 ? flags[1] : "-";
+
+        // Detect Chess960: Shredder-FEN uses file letters (A-H, a-h) for castling rights
+        boolean isShredderFen = false;
+        boolean isChess960 = false;
+        Square whiteRookOO = null, whiteRookOOO = null;
+        Square blackRookOO = null, blackRookOOO = null;
+
+        if (!castlingField.equals("-")) {
+            for (int ci = 0; ci < castlingField.length(); ci++) {
+                char ch = castlingField.charAt(ci);
+                if (ch >= 'A' && ch <= 'H') {
+                    isShredderFen = true;
+                    break;
+                }
+                if (ch >= 'a' && ch <= 'h') {
+                    isShredderFen = true;
+                    break;
+                }
+            }
+        }
+
+        if (isShredderFen) {
+            // Parse Shredder-FEN castling rights
+            isChess960 = true;
+            Square wKing = getKingSquare(Side.WHITE);
+            Square bKing = getKingSquare(Side.BLACK);
+            int wKingFile = wKing != Square.NONE ? wKing.getFile().ordinal() : -1;
+            int bKingFile = bKing != Square.NONE ? bKing.getFile().ordinal() : -1;
+
+            for (int ci = 0; ci < castlingField.length(); ci++) {
+                char ch = castlingField.charAt(ci);
+                if (ch >= 'A' && ch <= 'H') {
+                    int rookFile = ch - 'A';
+                    if (wKingFile >= 0 && rookFile > wKingFile) {
+                        whiteRookOO = Square.encode(Rank.RANK_1, File.allFiles[rookFile]);
+                    } else {
+                        whiteRookOOO = Square.encode(Rank.RANK_1, File.allFiles[rookFile]);
+                    }
+                } else if (ch >= 'a' && ch <= 'h') {
+                    int rookFile = ch - 'a';
+                    if (bKingFile >= 0 && rookFile > bKingFile) {
+                        blackRookOO = Square.encode(Rank.RANK_8, File.allFiles[rookFile]);
+                    } else {
+                        blackRookOOO = Square.encode(Rank.RANK_8, File.allFiles[rookFile]);
+                    }
+                }
+            }
+
+            // Set castle rights based on what we found
+            if (whiteRookOO != null && whiteRookOOO != null) {
+                castleRight.put(Side.WHITE, CastleRight.KING_AND_QUEEN_SIDE);
+            } else if (whiteRookOO != null) {
+                castleRight.put(Side.WHITE, CastleRight.KING_SIDE);
+            } else if (whiteRookOOO != null) {
+                castleRight.put(Side.WHITE, CastleRight.QUEEN_SIDE);
+            } else {
+                castleRight.put(Side.WHITE, CastleRight.NONE);
+            }
+
+            if (blackRookOO != null && blackRookOOO != null) {
+                castleRight.put(Side.BLACK, CastleRight.KING_AND_QUEEN_SIDE);
+            } else if (blackRookOO != null) {
+                castleRight.put(Side.BLACK, CastleRight.KING_SIDE);
+            } else if (blackRookOOO != null) {
+                castleRight.put(Side.BLACK, CastleRight.QUEEN_SIDE);
+            } else {
+                castleRight.put(Side.BLACK, CastleRight.NONE);
+            }
+        } else {
+            // Standard KQkq notation
+            if (castlingField.contains("K") && castlingField.contains("Q")) {
+                castleRight.put(Side.WHITE, CastleRight.KING_AND_QUEEN_SIDE);
+            } else if (castlingField.contains("K")) {
+                castleRight.put(Side.WHITE, CastleRight.KING_SIDE);
+            } else if (castlingField.contains("Q")) {
+                castleRight.put(Side.WHITE, CastleRight.QUEEN_SIDE);
+            } else {
+                castleRight.put(Side.WHITE, CastleRight.NONE);
+            }
+
+            if (castlingField.contains("k") && castlingField.contains("q")) {
+                castleRight.put(Side.BLACK, CastleRight.KING_AND_QUEEN_SIDE);
+            } else if (castlingField.contains("k")) {
+                castleRight.put(Side.BLACK, CastleRight.KING_SIDE);
+            } else if (castlingField.contains("q")) {
+                castleRight.put(Side.BLACK, CastleRight.QUEEN_SIDE);
+            } else {
+                castleRight.put(Side.BLACK, CastleRight.NONE);
+            }
+
+            // Detect Chess960 with KQkq notation: king not on e-file but has castling rights,
+            // or explicitly requested via chess960 flag (e.g. from PGN [Variant "Chess960"] tag)
+            if (!castlingField.equals("-")) {
+                Square wKing = getKingSquare(Side.WHITE);
+                Square bKing = getKingSquare(Side.BLACK);
+                boolean whiteNonStandard = wKing != Square.NONE && wKing != Square.E1
+                        && castleRight.get(Side.WHITE) != CastleRight.NONE;
+                boolean blackNonStandard = bKing != Square.NONE && bKing != Square.E8
+                        && castleRight.get(Side.BLACK) != CastleRight.NONE;
+
+                if (chess960 || whiteNonStandard || blackNonStandard) {
+                    isChess960 = true;
+                    // Find rooks by scanning the back rank
+                    if (castleRight.get(Side.WHITE) != CastleRight.NONE && wKing != Square.NONE) {
+                        int wkf = wKing.getFile().ordinal();
+                        if (castleRight.get(Side.WHITE) == CastleRight.KING_SIDE
+                                || castleRight.get(Side.WHITE) == CastleRight.KING_AND_QUEEN_SIDE) {
+                            // Find rook to the right of king
+                            for (int f = wkf + 1; f <= 7; f++) {
+                                Square sq = Square.encode(Rank.RANK_1, File.allFiles[f]);
+                                if (getPiece(sq) == Piece.WHITE_ROOK) {
+                                    whiteRookOO = sq;
+                                    break;
+                                }
+                            }
+                        }
+                        if (castleRight.get(Side.WHITE) == CastleRight.QUEEN_SIDE
+                                || castleRight.get(Side.WHITE) == CastleRight.KING_AND_QUEEN_SIDE) {
+                            // Find rook to the left of king
+                            for (int f = wkf - 1; f >= 0; f--) {
+                                Square sq = Square.encode(Rank.RANK_1, File.allFiles[f]);
+                                if (getPiece(sq) == Piece.WHITE_ROOK) {
+                                    whiteRookOOO = sq;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (castleRight.get(Side.BLACK) != CastleRight.NONE && bKing != Square.NONE) {
+                        int bkf = bKing.getFile().ordinal();
+                        if (castleRight.get(Side.BLACK) == CastleRight.KING_SIDE
+                                || castleRight.get(Side.BLACK) == CastleRight.KING_AND_QUEEN_SIDE) {
+                            for (int f = bkf + 1; f <= 7; f++) {
+                                Square sq = Square.encode(Rank.RANK_8, File.allFiles[f]);
+                                if (getPiece(sq) == Piece.BLACK_ROOK) {
+                                    blackRookOO = sq;
+                                    break;
+                                }
+                            }
+                        }
+                        if (castleRight.get(Side.BLACK) == CastleRight.QUEEN_SIDE
+                                || castleRight.get(Side.BLACK) == CastleRight.KING_AND_QUEEN_SIDE) {
+                            for (int f = bkf - 1; f >= 0; f--) {
+                                Square sq = Square.encode(Rank.RANK_8, File.allFiles[f]);
+                                if (getPiece(sq) == Piece.BLACK_ROOK) {
+                                    blackRookOOO = sq;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Configure Chess960 context if detected
+        if (isChess960) {
+            Square wKing = getKingSquare(Side.WHITE);
+            Square bKing = getKingSquare(Side.BLACK);
+            context.loadChess960(
+                    wKing != Square.NONE ? wKing : Square.E1,
+                    whiteRookOO, whiteRookOOO,
+                    bKing != Square.NONE ? bKing : Square.E8,
+                    blackRookOO, blackRookOOO
+            );
+        } else if (context.getVariationType() == VariationType.CHESS960) {
+            // Reset to standard if previously was Chess960 (e.g., thread-local board reuse)
+            context = new GameContext();
+        }
 
         if (flags.length >= 3) {
             String s = flags[2].toUpperCase().trim();
@@ -934,26 +1120,54 @@ public class Board implements Cloneable, BoardEvent {
         }
 
         String rights = StringUtils.EMPTY;
-        if (CastleRight.KING_AND_QUEEN_SIDE.
-                equals(castleRight.get(Side.WHITE))) {
-            rights += "KQ";
-        } else if (CastleRight.KING_SIDE.
-                equals(castleRight.get(Side.WHITE))) {
-            rights += "K";
-        } else if (CastleRight.QUEEN_SIDE.
-                equals(castleRight.get(Side.WHITE))) {
-            rights += "Q";
-        }
+        if (context.getVariationType() == VariationType.CHESS960) {
+            // Shredder-FEN: use file letters for castling rights
+            if (CastleRight.KING_AND_QUEEN_SIDE.equals(castleRight.get(Side.WHITE))
+                    || CastleRight.KING_SIDE.equals(castleRight.get(Side.WHITE))) {
+                if (context.getWhiteRookooFile() != null) {
+                    rights += context.getWhiteRookooFile().getNotation().toUpperCase();
+                }
+            }
+            if (CastleRight.KING_AND_QUEEN_SIDE.equals(castleRight.get(Side.WHITE))
+                    || CastleRight.QUEEN_SIDE.equals(castleRight.get(Side.WHITE))) {
+                if (context.getWhiteRookoooFile() != null) {
+                    rights += context.getWhiteRookoooFile().getNotation().toUpperCase();
+                }
+            }
+            if (CastleRight.KING_AND_QUEEN_SIDE.equals(castleRight.get(Side.BLACK))
+                    || CastleRight.KING_SIDE.equals(castleRight.get(Side.BLACK))) {
+                if (context.getBlackRookooFile() != null) {
+                    rights += context.getBlackRookooFile().getNotation().toLowerCase();
+                }
+            }
+            if (CastleRight.KING_AND_QUEEN_SIDE.equals(castleRight.get(Side.BLACK))
+                    || CastleRight.QUEEN_SIDE.equals(castleRight.get(Side.BLACK))) {
+                if (context.getBlackRookoooFile() != null) {
+                    rights += context.getBlackRookoooFile().getNotation().toLowerCase();
+                }
+            }
+        } else {
+            if (CastleRight.KING_AND_QUEEN_SIDE.
+                    equals(castleRight.get(Side.WHITE))) {
+                rights += "KQ";
+            } else if (CastleRight.KING_SIDE.
+                    equals(castleRight.get(Side.WHITE))) {
+                rights += "K";
+            } else if (CastleRight.QUEEN_SIDE.
+                    equals(castleRight.get(Side.WHITE))) {
+                rights += "Q";
+            }
 
-        if (CastleRight.KING_AND_QUEEN_SIDE.
-                equals(castleRight.get(Side.BLACK))) {
-            rights += "kq";
-        } else if (CastleRight.KING_SIDE.
-                equals(castleRight.get(Side.BLACK))) {
-            rights += "k";
-        } else if (CastleRight.QUEEN_SIDE.
-                equals(castleRight.get(Side.BLACK))) {
-            rights += "q";
+            if (CastleRight.KING_AND_QUEEN_SIDE.
+                    equals(castleRight.get(Side.BLACK))) {
+                rights += "kq";
+            } else if (CastleRight.KING_SIDE.
+                    equals(castleRight.get(Side.BLACK))) {
+                rights += "k";
+            } else if (CastleRight.QUEEN_SIDE.
+                    equals(castleRight.get(Side.BLACK))) {
+                rights += "q";
+            }
         }
 
         if (StringUtils.isEmpty(rights)) {
@@ -1210,7 +1424,10 @@ public class Board implements Cloneable, BoardEvent {
                 return false;
             }
 
-            if (fromPiece.getPieceSide().equals(capturedPiece.getPieceSide())) {
+            // In Chess960 castling, the king may move to a square occupied by own rook
+            // (e.g., if rook is on G1 and king castles to G1). Skip the same-side capture check for castle moves.
+            if (fromPiece.getPieceSide().equals(capturedPiece.getPieceSide())
+                    && !(fromType.equals(PieceType.KING) && getContext().isCastleMove(move))) {
                 return false;
             }
 
@@ -1229,7 +1446,16 @@ public class Board implements Cloneable, BoardEvent {
                 if (getContext().isKingSideCastle(move)) {
                     if (getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
                             (getCastleRight(side).equals(CastleRight.KING_SIDE))) {
-                        if ((getBitboard() & getContext().getooAllSquaresBb(side)) == 0L) {
+                        long occ = getBitboard();
+                        if (context.getVariationType() == VariationType.CHESS960) {
+                            // Exclude king and rook from occupancy check
+                            occ &= ~move.getFrom().getBitboard();
+                            Move rookMove = context.getRookoo(side);
+                            if (rookMove != null) {
+                                occ &= ~rookMove.getFrom().getBitboard();
+                            }
+                        }
+                        if ((occ & getContext().getooAllSquaresBb(side)) == 0L) {
                             return !isSquareAttackedBy(getContext().getooSquares(side), side.flip());
                         }
                     }
@@ -1238,7 +1464,15 @@ public class Board implements Cloneable, BoardEvent {
                 if (getContext().isQueenSideCastle(move)) {
                     if (getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
                             (getCastleRight(side).equals(CastleRight.QUEEN_SIDE))) {
-                        if ((getBitboard() & getContext().getoooAllSquaresBb(side)) == 0L) {
+                        long occ = getBitboard();
+                        if (context.getVariationType() == VariationType.CHESS960) {
+                            occ &= ~move.getFrom().getBitboard();
+                            Move rookMove = context.getRookooo(side);
+                            if (rookMove != null) {
+                                occ &= ~rookMove.getFrom().getBitboard();
+                            }
+                        }
+                        if ((occ & getContext().getoooAllSquaresBb(side)) == 0L) {
                             return !isSquareAttackedBy(getContext().getoooSquares(side), side.flip());
                         }
                     }
@@ -1247,9 +1481,17 @@ public class Board implements Cloneable, BoardEvent {
             }
         }
         if (fromType.equals(PieceType.KING)) {
-            if (squareAttackedBy(move.getTo(), side.flip()) != 0L) {
-                return false;
+            // For Chess960 castling, skip the attack check on king destination here
+            // (it's already checked via ooSquares above in fullValidation, and in generateCastleMoves)
+            if (!(context.getVariationType() == VariationType.CHESS960 && context.isCastleMove(move))) {
+                if (squareAttackedBy(move.getTo(), side.flip()) != 0L) {
+                    return false;
+                }
             }
+        }
+        // For Chess960 castling, the pin/attack detection below doesn't apply
+        if (context.getVariationType() == VariationType.CHESS960 && context.isCastleMove(move)) {
+            return true;
         }
         Square kingSq = (fromType.equals(PieceType.KING) ?
                 move.getTo() : getKingSquare(side));

--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -262,6 +262,13 @@ public class Board implements Cloneable, BoardEvent {
                 Move rookMove = context.getRookCastleMove(side, c);
                 if (context.getVariationType() == VariationType.CHESS960) {
                     // Chess960: manually handle piece placement to avoid capture issues
+                    // Determine the king's final destination square (always c1/g1 or c8/g8)
+                    Square kingDest;
+                    if (side == Side.WHITE) {
+                        kingDest = c == CastleRight.KING_SIDE ? Square.G1 : Square.C1;
+                    } else {
+                        kingDest = c == CastleRight.KING_SIDE ? Square.G8 : Square.C8;
+                    }
                     Piece king = getPiece(move.getFrom());
                     Piece rook = getPiece(rookMove.getFrom());
                     unsetPiece(king, move.getFrom());
@@ -269,11 +276,7 @@ public class Board implements Cloneable, BoardEvent {
                         unsetPiece(rook, rookMove.getFrom());
                     }
                     setPiece(rook, rookMove.getTo());
-                    if (!move.getTo().equals(rookMove.getTo())) {
-                        setPiece(king, move.getTo());
-                    } else {
-                        setPiece(king, move.getTo());
-                    }
+                    setPiece(king, kingDest);
                 } else {
                     movePiece(rookMove, backupMove);
                 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -221,7 +221,34 @@ public class Board implements Cloneable, BoardEvent {
         Side side = getSideToMove();
 
         MoveBackup backupMove = new MoveBackup(this, move);
-        final boolean isCastle = context.isCastleMove(move);
+        final boolean isCastle;
+        if (context.isCastleMove(move)
+                && PieceType.KING.equals(movingPiece.getPieceType())
+                && getCastleRight(side) != CastleRight.NONE) {
+            if (context.getVariationType() == VariationType.CHESS960) {
+                // Determine if this is actually a castle or a normal king move:
+                // - If from == to: always a castle (king already on final square)
+                // - If destination has an enemy piece: never a castle (it's a capture)
+                // - If destination is empty: castle only if the rook is on its initial square
+                // - If destination has own rook on rook's initial square: castle
+                Piece destPiece = getPiece(move.getTo());
+                if (move.getFrom() == move.getTo()) {
+                    isCastle = true;
+                } else if (destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side)) {
+                    // Destination has enemy piece — this is a capture, not a castle
+                    isCastle = false;
+                } else {
+                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
+                    Move rookMove = context.getRookCastleMove(side, c);
+                    Piece expectedRook = Piece.make(side, PieceType.ROOK);
+                    isCastle = rookMove != null && getPiece(rookMove.getFrom()) == expectedRook;
+                }
+            } else {
+                isCastle = true;
+            }
+        } else {
+            isCastle = false;
+        }
 
         incrementalHashKey ^= getSideKey(getSideToMove());
         if (getEnPassantTarget() != Square.NONE) {
@@ -230,29 +257,25 @@ public class Board implements Cloneable, BoardEvent {
 
         if (PieceType.KING.equals(movingPiece.getPieceType())) {
             if (isCastle) {
-                if (context.hasCastleRight(move, getCastleRight(side))) {
-                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE :
-                            CastleRight.QUEEN_SIDE;
-                    Move rookMove = context.getRookCastleMove(side, c);
-                    if (context.getVariationType() == VariationType.CHESS960) {
-                        // Chess960: manually handle piece placement to avoid capture issues
-                        Piece king = getPiece(move.getFrom());
-                        Piece rook = getPiece(rookMove.getFrom());
-                        unsetPiece(king, move.getFrom());
-                        if (!rookMove.getFrom().equals(move.getFrom())) {
-                            unsetPiece(rook, rookMove.getFrom());
-                        }
-                        setPiece(rook, rookMove.getTo());
-                        if (!move.getTo().equals(rookMove.getTo())) {
-                            setPiece(king, move.getTo());
-                        } else {
-                            setPiece(king, move.getTo());
-                        }
+                CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE :
+                        CastleRight.QUEEN_SIDE;
+                Move rookMove = context.getRookCastleMove(side, c);
+                if (context.getVariationType() == VariationType.CHESS960) {
+                    // Chess960: manually handle piece placement to avoid capture issues
+                    Piece king = getPiece(move.getFrom());
+                    Piece rook = getPiece(rookMove.getFrom());
+                    unsetPiece(king, move.getFrom());
+                    if (!rookMove.getFrom().equals(move.getFrom())) {
+                        unsetPiece(rook, rookMove.getFrom());
+                    }
+                    setPiece(rook, rookMove.getTo());
+                    if (!move.getTo().equals(rookMove.getTo())) {
+                        setPiece(king, move.getTo());
                     } else {
-                        movePiece(rookMove, backupMove);
+                        setPiece(king, move.getTo());
                     }
                 } else {
-                    return false;
+                    movePiece(rookMove, backupMove);
                 }
             }
             if (getCastleRight(side) != CastleRight.NONE) {
@@ -1424,11 +1447,26 @@ public class Board implements Cloneable, BoardEvent {
                 return false;
             }
 
-            // In Chess960 castling, the king may move to a square occupied by own rook
-            // (e.g., if rook is on G1 and king castles to G1). Skip the same-side capture check for castle moves.
-            if (fromPiece.getPieceSide().equals(capturedPiece.getPieceSide())
-                    && !(fromType.equals(PieceType.KING) && getContext().isCastleMove(move))) {
-                return false;
+            // In Chess960 castling, the king moves to the rook's square (own piece).
+            // Special case: when from == to (king already on final square), skip capture check.
+            if (fromPiece.getPieceSide().equals(capturedPiece.getPieceSide())) {
+                boolean allowCapture = false;
+                if (fromType.equals(PieceType.KING)
+                        && context.getVariationType() == VariationType.CHESS960
+                        && getContext().isCastleMove(move)
+                        && getCastleRight(side) != CastleRight.NONE) {
+                    if (move.getFrom() == move.getTo()) {
+                        // King stays in place (already on final square) — always a castle
+                        allowCapture = true;
+                    } else if (capturedPiece.getPieceType().equals(PieceType.ROOK)) {
+                        CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
+                        Move rookMv = context.getRookCastleMove(side, c);
+                        allowCapture = rookMv != null && move.getTo() == rookMv.getFrom();
+                    }
+                }
+                if (!allowCapture) {
+                    return false;
+                }
             }
 
             if (!side.equals(fromPiece.getPieceSide())) {
@@ -1443,55 +1481,110 @@ public class Board implements Cloneable, BoardEvent {
                 return false;
             }
             if (fromType.equals(PieceType.KING)) {
-                if (getContext().isKingSideCastle(move)) {
-                    if (getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
-                            (getCastleRight(side).equals(CastleRight.KING_SIDE))) {
-                        long occ = getBitboard();
-                        if (context.getVariationType() == VariationType.CHESS960) {
-                            // Exclude king and rook from occupancy check
-                            occ &= ~move.getFrom().getBitboard();
-                            Move rookMove = context.getRookoo(side);
-                            if (rookMove != null) {
-                                occ &= ~rookMove.getFrom().getBitboard();
-                            }
+                // In Chess960, only enter castling validation if:
+                // - rook is on its initial square AND
+                // - destination does NOT have an enemy piece (captures are never castles)
+                boolean rookOnSquareOO = true;
+                boolean rookOnSquareOOO = true;
+                if (context.getVariationType() == VariationType.CHESS960) {
+                    Piece destPiece = getPiece(move.getTo());
+                    boolean destHasEnemy = destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side);
+                    if (destHasEnemy) {
+                        rookOnSquareOO = false;
+                        rookOnSquareOOO = false;
+                    } else if (move.getFrom() == move.getTo()) {
+                        rookOnSquareOO = true;
+                        rookOnSquareOOO = true;
+                    } else {
+                        Move rookOO = context.getRookoo(side);
+                        Move rookOOO = context.getRookooo(side);
+                        Piece expectedRook = Piece.make(side, PieceType.ROOK);
+                        rookOnSquareOO = rookOO != null && getPiece(rookOO.getFrom()) == expectedRook;
+                        rookOnSquareOOO = rookOOO != null && getPiece(rookOOO.getFrom()) == expectedRook;
+                    }
+                }
+
+                if (getContext().isKingSideCastle(move) && rookOnSquareOO &&
+                        (getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
+                         getCastleRight(side).equals(CastleRight.KING_SIDE))) {
+                    long occ = getBitboard();
+                    if (context.getVariationType() == VariationType.CHESS960) {
+                        occ &= ~move.getFrom().getBitboard();
+                        Move rookMove = context.getRookoo(side);
+                        if (rookMove != null) {
+                            occ &= ~rookMove.getFrom().getBitboard();
                         }
-                        if ((occ & getContext().getooAllSquaresBb(side)) == 0L) {
-                            return !isSquareAttackedBy(getContext().getooSquares(side), side.flip());
-                        }
+                    }
+                    if ((occ & getContext().getooAllSquaresBb(side)) == 0L) {
+                        return !isSquareAttackedBy(getContext().getooSquares(side), side.flip());
                     }
                     return false;
                 }
-                if (getContext().isQueenSideCastle(move)) {
-                    if (getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
-                            (getCastleRight(side).equals(CastleRight.QUEEN_SIDE))) {
-                        long occ = getBitboard();
-                        if (context.getVariationType() == VariationType.CHESS960) {
-                            occ &= ~move.getFrom().getBitboard();
-                            Move rookMove = context.getRookooo(side);
-                            if (rookMove != null) {
-                                occ &= ~rookMove.getFrom().getBitboard();
-                            }
+                if (getContext().isQueenSideCastle(move) && rookOnSquareOOO &&
+                        (getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
+                         getCastleRight(side).equals(CastleRight.QUEEN_SIDE))) {
+                    long occ = getBitboard();
+                    if (context.getVariationType() == VariationType.CHESS960) {
+                        occ &= ~move.getFrom().getBitboard();
+                        Move rookMove = context.getRookooo(side);
+                        if (rookMove != null) {
+                            occ &= ~rookMove.getFrom().getBitboard();
                         }
-                        if ((occ & getContext().getoooAllSquaresBb(side)) == 0L) {
-                            return !isSquareAttackedBy(getContext().getoooSquares(side), side.flip());
-                        }
+                    }
+                    if ((occ & getContext().getoooAllSquaresBb(side)) == 0L) {
+                        return !isSquareAttackedBy(getContext().getoooSquares(side), side.flip());
                     }
                     return false;
                 }
             }
         }
         if (fromType.equals(PieceType.KING)) {
-            // For Chess960 castling, skip the attack check on king destination here
-            // (it's already checked via ooSquares above in fullValidation, and in generateCastleMoves)
-            if (!(context.getVariationType() == VariationType.CHESS960 && context.isCastleMove(move))) {
+            // For Chess960 castling, skip the attack check on king destination
+            boolean isActualCastle = false;
+            if (context.getVariationType() == VariationType.CHESS960
+                    && context.isCastleMove(move)
+                    && getCastleRight(side) != CastleRight.NONE) {
+                Piece destPiece = getPiece(move.getTo());
+                boolean destHasEnemy = destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side);
+                if (move.getFrom() == move.getTo()) {
+                    isActualCastle = true;
+                } else if (destHasEnemy) {
+                    isActualCastle = false;
+                } else {
+                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
+                    Move rookMv = context.getRookCastleMove(side, c);
+                    Piece expectedRook = Piece.make(side, PieceType.ROOK);
+                    isActualCastle = rookMv != null && getPiece(rookMv.getFrom()) == expectedRook;
+                }
+            }
+            if (!isActualCastle) {
                 if (squareAttackedBy(move.getTo(), side.flip()) != 0L) {
                     return false;
                 }
             }
         }
         // For Chess960 castling, the pin/attack detection below doesn't apply
-        if (context.getVariationType() == VariationType.CHESS960 && context.isCastleMove(move)) {
-            return true;
+        {
+            boolean isActualCastle = false;
+            if (context.getVariationType() == VariationType.CHESS960
+                    && context.isCastleMove(move)
+                    && getCastleRight(side) != CastleRight.NONE) {
+                Piece destPiece = getPiece(move.getTo());
+                boolean destHasEnemy = destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side);
+                if (move.getFrom() == move.getTo()) {
+                    isActualCastle = true;
+                } else if (destHasEnemy) {
+                    isActualCastle = false;
+                } else {
+                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
+                    Move rookMv = context.getRookCastleMove(side, c);
+                    Piece expectedRook = Piece.make(side, PieceType.ROOK);
+                    isActualCastle = rookMv != null && getPiece(rookMv.getFrom()) == expectedRook;
+                }
+            }
+            if (isActualCastle) {
+                return true;
+            }
         }
         Square kingSq = (fromType.equals(PieceType.KING) ?
                 move.getTo() : getKingSquare(side));

--- a/src/main/java/com/github/bhlangonijr/chesslib/Board.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/Board.java
@@ -222,27 +222,11 @@ public class Board implements Cloneable, BoardEvent {
 
         MoveBackup backupMove = new MoveBackup(this, move);
         final boolean isCastle;
-        if (context.isCastleMove(move)
-                && PieceType.KING.equals(movingPiece.getPieceType())
-                && getCastleRight(side) != CastleRight.NONE) {
+        if (PieceType.KING.equals(movingPiece.getPieceType())
+                && getCastleRight(side) != CastleRight.NONE
+                && context.isCastleMove(move)) {
             if (context.getVariationType() == VariationType.CHESS960) {
-                // Determine if this is actually a castle or a normal king move:
-                // - If from == to: always a castle (king already on final square)
-                // - If destination has an enemy piece: never a castle (it's a capture)
-                // - If destination is empty: castle only if the rook is on its initial square
-                // - If destination has own rook on rook's initial square: castle
-                Piece destPiece = getPiece(move.getTo());
-                if (move.getFrom() == move.getTo()) {
-                    isCastle = true;
-                } else if (destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side)) {
-                    // Destination has enemy piece — this is a capture, not a castle
-                    isCastle = false;
-                } else {
-                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
-                    Move rookMove = context.getRookCastleMove(side, c);
-                    Piece expectedRook = Piece.make(side, PieceType.ROOK);
-                    isCastle = rookMove != null && getPiece(rookMove.getFrom()) == expectedRook;
-                }
+                isCastle = isChess960Castle(move, side);
             } else {
                 isCastle = true;
             }
@@ -1455,17 +1439,8 @@ public class Board implements Cloneable, BoardEvent {
             if (fromPiece.getPieceSide().equals(capturedPiece.getPieceSide())) {
                 boolean allowCapture = false;
                 if (fromType.equals(PieceType.KING)
-                        && context.getVariationType() == VariationType.CHESS960
-                        && getContext().isCastleMove(move)
-                        && getCastleRight(side) != CastleRight.NONE) {
-                    if (move.getFrom() == move.getTo()) {
-                        // King stays in place (already on final square) — always a castle
-                        allowCapture = true;
-                    } else if (capturedPiece.getPieceType().equals(PieceType.ROOK)) {
-                        CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
-                        Move rookMv = context.getRookCastleMove(side, c);
-                        allowCapture = rookMv != null && move.getTo() == rookMv.getFrom();
-                    }
+                        && context.getVariationType() == VariationType.CHESS960) {
+                    allowCapture = isChess960Castle(move, side);
                 }
                 if (!allowCapture) {
                     return false;
@@ -1495,10 +1470,7 @@ public class Board implements Cloneable, BoardEvent {
                     if (destHasEnemy) {
                         rookOnSquareOO = false;
                         rookOnSquareOOO = false;
-                    } else if (move.getFrom() == move.getTo()) {
-                        rookOnSquareOO = true;
-                        rookOnSquareOOO = true;
-                    } else {
+                    } else if (move.getFrom() != move.getTo()) {
                         Move rookOO = context.getRookoo(side);
                         Move rookOOO = context.getRookooo(side);
                         Piece expectedRook = Piece.make(side, PieceType.ROOK);
@@ -1543,51 +1515,15 @@ public class Board implements Cloneable, BoardEvent {
         }
         if (fromType.equals(PieceType.KING)) {
             // For Chess960 castling, skip the attack check on king destination
-            boolean isActualCastle = false;
-            if (context.getVariationType() == VariationType.CHESS960
-                    && context.isCastleMove(move)
-                    && getCastleRight(side) != CastleRight.NONE) {
-                Piece destPiece = getPiece(move.getTo());
-                boolean destHasEnemy = destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side);
-                if (move.getFrom() == move.getTo()) {
-                    isActualCastle = true;
-                } else if (destHasEnemy) {
-                    isActualCastle = false;
-                } else {
-                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
-                    Move rookMv = context.getRookCastleMove(side, c);
-                    Piece expectedRook = Piece.make(side, PieceType.ROOK);
-                    isActualCastle = rookMv != null && getPiece(rookMv.getFrom()) == expectedRook;
-                }
-            }
-            if (!isActualCastle) {
+            if (context.getVariationType() != VariationType.CHESS960 || !isChess960Castle(move, side)) {
                 if (squareAttackedBy(move.getTo(), side.flip()) != 0L) {
                     return false;
                 }
             }
         }
         // For Chess960 castling, the pin/attack detection below doesn't apply
-        {
-            boolean isActualCastle = false;
-            if (context.getVariationType() == VariationType.CHESS960
-                    && context.isCastleMove(move)
-                    && getCastleRight(side) != CastleRight.NONE) {
-                Piece destPiece = getPiece(move.getTo());
-                boolean destHasEnemy = destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side);
-                if (move.getFrom() == move.getTo()) {
-                    isActualCastle = true;
-                } else if (destHasEnemy) {
-                    isActualCastle = false;
-                } else {
-                    CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
-                    Move rookMv = context.getRookCastleMove(side, c);
-                    Piece expectedRook = Piece.make(side, PieceType.ROOK);
-                    isActualCastle = rookMv != null && getPiece(rookMv.getFrom()) == expectedRook;
-                }
-            }
-            if (isActualCastle) {
-                return true;
-            }
+        if (context.getVariationType() == VariationType.CHESS960 && isChess960Castle(move, side)) {
+            return true;
         }
         Square kingSq = (fromType.equals(PieceType.KING) ?
                 move.getTo() : getKingSquare(side));
@@ -2187,6 +2123,42 @@ public class Board implements Cloneable, BoardEvent {
      */
     public void setIncrementalHashKey(long hashKey) {
         incrementalHashKey = hashKey;
+    }
+
+    /**
+     * Determines whether the given move is an actual Chess960 castling move.
+     * <p>
+     * In Chess960, the king "captures" its own rook to castle, but certain king moves
+     * to squares occupied by friendly rooks could also be normal captures in some edge cases.
+     * This helper resolves the ambiguity by checking:
+     * <ul>
+     *   <li>The move is recognized as a castle by the game context</li>
+     *   <li>The side still has castling rights</li>
+     *   <li>The destination is not occupied by an enemy piece (which would make it a capture)</li>
+     *   <li>The rook is on its expected initial square (or king from==to, meaning it stays in place)</li>
+     * </ul>
+     * <p>
+     * This method should only be called when the variant is Chess960 and the moving piece is a king.
+     *
+     * @param move the king move to evaluate
+     * @param side the side of the moving king
+     * @return {@code true} if the move is a genuine Chess960 castle
+     */
+    boolean isChess960Castle(Move move, Side side) {
+        if (!context.isCastleMove(move) || getCastleRight(side) == CastleRight.NONE) {
+            return false;
+        }
+        if (move.getFrom() == move.getTo()) {
+            return true; // King already on final square — always a castle
+        }
+        Piece destPiece = getPiece(move.getTo());
+        if (destPiece != Piece.NONE && !destPiece.getPieceSide().equals(side)) {
+            return false; // Destination has enemy piece — this is a capture, not a castle
+        }
+        CastleRight c = context.isKingSideCastle(move) ? CastleRight.KING_SIDE : CastleRight.QUEEN_SIDE;
+        Move rookMove = context.getRookCastleMove(side, c);
+        Piece expectedRook = Piece.make(side, PieceType.ROOK);
+        return rookMove != null && getPiece(rookMove.getFrom()) == expectedRook;
     }
 
     private boolean pawnCanBeCapturedEnPassant() {

--- a/src/main/java/com/github/bhlangonijr/chesslib/MoveBackup.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/MoveBackup.java
@@ -16,10 +16,10 @@
 
 package com.github.bhlangonijr.chesslib;
 
-import static com.github.bhlangonijr.chesslib.Constants.emptyMove;
-
 import java.util.EnumMap;
 
+import static com.github.bhlangonijr.chesslib.Constants.emptyMove;
+import com.github.bhlangonijr.chesslib.game.VariationType;
 import com.github.bhlangonijr.chesslib.move.Move;
 
 /**
@@ -123,6 +123,24 @@ public class MoveBackup implements BoardEvent {
             final boolean isCastle = board.getContext().isCastleMove(getMove());
 
             if (PieceType.KING.equals(movingPiece.getPieceType()) && isCastle) {
+                if (board.getContext().getVariationType() == VariationType.CHESS960) {
+                    // Chess960: clear both pieces from their destination squares, then restore them
+                    Piece king = Piece.make(getSideToMove(), PieceType.KING);
+                    Piece rook = Piece.make(getSideToMove(), PieceType.ROOK);
+                    Move rookMove = getRookCastleMove();
+                    board.unsetPiece(king, getMove().getTo());
+                    if (!rookMove.getTo().equals(getMove().getTo())) {
+                        board.unsetPiece(rook, rookMove.getTo());
+                    }
+                    board.setPiece(rook, rookMove.getFrom());
+                    if (!getMove().getFrom().equals(rookMove.getFrom())) {
+                        board.setPiece(king, getMove().getFrom());
+                    } else {
+                        board.setPiece(king, getMove().getFrom());
+                    }
+                    board.setIncrementalHashKey(getIncrementalHashKey());
+                    return;
+                }
                 board.undoMovePiece(getRookCastleMove());
             }
             board.unsetPiece(movingPiece, getMove().getTo());

--- a/src/main/java/com/github/bhlangonijr/chesslib/MoveBackup.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/MoveBackup.java
@@ -87,12 +87,30 @@ public class MoveBackup implements BoardEvent {
         setCapturedSquare(move.getTo());
         Piece moving = board.getPiece(move.getFrom());
         setMovingPiece(moving);
-        if (board.getContext().isCastleMove(move) && movingPiece == Piece.make(board.getSideToMove(), PieceType.KING)) {
-            CastleRight c = board.getContext().isKingSideCastle(move) ? CastleRight.KING_SIDE :
-                    CastleRight.QUEEN_SIDE;
-            Move rookMove = board.getContext().getRookCastleMove(board.getSideToMove(), c);
-            setRookCastleMove(rookMove);
-            setCastleMove(true);
+        if (board.getContext().isCastleMove(move) && movingPiece == Piece.make(board.getSideToMove(), PieceType.KING)
+                && board.getCastleRight(board.getSideToMove()) != CastleRight.NONE) {
+            boolean actualCastle = true;
+            if (board.getContext().getVariationType() == VariationType.CHESS960) {
+                if (move.getFrom() == move.getTo()) {
+                    actualCastle = true; // King stays in place — always a castle
+                } else {
+                    CastleRight c = board.getContext().isKingSideCastle(move) ? CastleRight.KING_SIDE :
+                            CastleRight.QUEEN_SIDE;
+                    Move rookMv = board.getContext().getRookCastleMove(board.getSideToMove(), c);
+                    Piece expectedRook = Piece.make(board.getSideToMove(), PieceType.ROOK);
+                    actualCastle = rookMv != null && board.getPiece(rookMv.getFrom()) == expectedRook;
+                }
+            }
+            if (actualCastle) {
+                CastleRight c = board.getContext().isKingSideCastle(move) ? CastleRight.KING_SIDE :
+                        CastleRight.QUEEN_SIDE;
+                Move rookMove = board.getContext().getRookCastleMove(board.getSideToMove(), c);
+                setRookCastleMove(rookMove);
+                setCastleMove(true);
+            } else {
+                setRookCastleMove(null);
+                setCastleMove(false);
+            }
         } else {
             setRookCastleMove(null);
             setCastleMove(false);
@@ -120,7 +138,7 @@ public class MoveBackup implements BoardEvent {
         board.getCastleRight().put(Side.BLACK, getCastleRight().get(Side.BLACK));
 
         if (move != emptyMove) {
-            final boolean isCastle = board.getContext().isCastleMove(getMove());
+            final boolean isCastle = isCastleMove();
 
             if (PieceType.KING.equals(movingPiece.getPieceType()) && isCastle) {
                 if (board.getContext().getVariationType() == VariationType.CHESS960) {

--- a/src/main/java/com/github/bhlangonijr/chesslib/MoveBackup.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/MoveBackup.java
@@ -89,17 +89,11 @@ public class MoveBackup implements BoardEvent {
         setMovingPiece(moving);
         if (board.getContext().isCastleMove(move) && movingPiece == Piece.make(board.getSideToMove(), PieceType.KING)
                 && board.getCastleRight(board.getSideToMove()) != CastleRight.NONE) {
-            boolean actualCastle = true;
+            boolean actualCastle;
             if (board.getContext().getVariationType() == VariationType.CHESS960) {
-                if (move.getFrom() == move.getTo()) {
-                    actualCastle = true; // King stays in place — always a castle
-                } else {
-                    CastleRight c = board.getContext().isKingSideCastle(move) ? CastleRight.KING_SIDE :
-                            CastleRight.QUEEN_SIDE;
-                    Move rookMv = board.getContext().getRookCastleMove(board.getSideToMove(), c);
-                    Piece expectedRook = Piece.make(board.getSideToMove(), PieceType.ROOK);
-                    actualCastle = rookMv != null && board.getPiece(rookMv.getFrom()) == expectedRook;
-                }
+                actualCastle = board.isChess960Castle(move, board.getSideToMove());
+            } else {
+                actualCastle = true;
             }
             if (actualCastle) {
                 CastleRight c = board.getContext().isKingSideCastle(move) ? CastleRight.KING_SIDE :
@@ -151,11 +145,7 @@ public class MoveBackup implements BoardEvent {
                         board.unsetPiece(rook, rookMove.getTo());
                     }
                     board.setPiece(rook, rookMove.getFrom());
-                    if (!getMove().getFrom().equals(rookMove.getFrom())) {
-                        board.setPiece(king, getMove().getFrom());
-                    } else {
-                        board.setPiece(king, getMove().getFrom());
-                    }
+                    board.setPiece(king, getMove().getFrom());
                     board.setIncrementalHashKey(getIncrementalHashKey());
                     return;
                 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/game/GameContext.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/game/GameContext.java
@@ -16,13 +16,16 @@
 
 package com.github.bhlangonijr.chesslib.game;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.github.bhlangonijr.chesslib.CastleRight;
 import com.github.bhlangonijr.chesslib.Constants;
+import com.github.bhlangonijr.chesslib.File;
+import com.github.bhlangonijr.chesslib.Rank;
 import com.github.bhlangonijr.chesslib.Side;
 import com.github.bhlangonijr.chesslib.Square;
 import com.github.bhlangonijr.chesslib.move.Move;
-
-import java.util.List;
 
 /**
  * The definition of a game context, a support structure used to provide contextual information to a chess position, and
@@ -122,6 +125,23 @@ public class GameContext {
     protected String startFEN;
 
     /**
+     * The file of the white king-side rook (for Shredder-FEN output in Chess960).
+     */
+    protected File whiteRookooFile;
+    /**
+     * The file of the white queen-side rook (for Shredder-FEN output in Chess960).
+     */
+    protected File whiteRookoooFile;
+    /**
+     * The file of the black king-side rook (for Shredder-FEN output in Chess960).
+     */
+    protected File blackRookooFile;
+    /**
+     * The file of the black queen-side rook (for Shredder-FEN output in Chess960).
+     */
+    protected File blackRookoooFile;
+
+    /**
      * The game mode.
      */
     protected GameMode gameMode;
@@ -194,6 +214,143 @@ public class GameContext {
 
         setStartFEN(Constants.startStandardFENPosition);
     }
+
+    /**
+     * Configures this game context for Chess960 based on the actual king and rook positions.
+     *
+     * @param whiteKing     the starting square of the white king
+     * @param whiteRookOO   the starting square of the white king-side rook (may be null if no king-side castling)
+     * @param whiteRookOOO  the starting square of the white queen-side rook (may be null if no queen-side castling)
+     * @param blackKing     the starting square of the black king
+     * @param blackRookOO   the starting square of the black king-side rook (may be null if no king-side castling)
+     * @param blackRookOOO  the starting square of the black queen-side rook (may be null if no queen-side castling)
+     */
+    public void loadChess960(Square whiteKing, Square whiteRookOO, Square whiteRookOOO,
+                             Square blackKing, Square blackRookOO, Square blackRookOOO) {
+        setVariationType(VariationType.CHESS960);
+
+        // King castle moves: king_from -> king_final_square
+        setWhiteoo(new Move(whiteKing, Square.G1));
+        setWhiteooo(new Move(whiteKing, Square.C1));
+        setBlackoo(new Move(blackKing, Square.G8));
+        setBlackooo(new Move(blackKing, Square.C8));
+
+        // Rook castle moves: rook_from -> rook_final_square
+        if (whiteRookOO != null) {
+            setWhiteRookoo(new Move(whiteRookOO, Square.F1));
+            whiteRookooFile = whiteRookOO.getFile();
+        }
+        if (whiteRookOOO != null) {
+            setWhiteRookooo(new Move(whiteRookOOO, Square.D1));
+            whiteRookoooFile = whiteRookOOO.getFile();
+        }
+        if (blackRookOO != null) {
+            setBlackRookoo(new Move(blackRookOO, Square.F8));
+            blackRookooFile = blackRookOO.getFile();
+        }
+        if (blackRookOOO != null) {
+            setBlackRookooo(new Move(blackRookOOO, Square.D8));
+            blackRookoooFile = blackRookOOO.getFile();
+        }
+
+        // Squares the king passes through (for attack checks) - between king start and king dest, inclusive of dest
+        setWhiteooSquares(computeKingPassSquares(whiteKing, Square.G1));
+        setWhiteoooSquares(computeKingPassSquares(whiteKing, Square.C1));
+        setBlackooSquares(computeKingPassSquares(blackKing, Square.G8));
+        setBlackoooSquares(computeKingPassSquares(blackKing, Square.C8));
+
+        setWhiteooSquaresBb(squareListToBb(getWhiteooSquares()));
+        setWhiteoooSquaresBb(squareListToBb(getWhiteoooSquares()));
+        setBlackooSquaresBb(squareListToBb(getBlackooSquares()));
+        setBlackoooSquaresBb(squareListToBb(getBlackoooSquares()));
+
+        // All squares that must be empty for castling (between king and king dest + between rook and rook dest)
+        // Exclude the king and rook starting squares themselves
+        setWhiteooAllSquaresBb(computeAllEmptySquaresBb(whiteKing, Square.G1, whiteRookOO, Square.F1));
+        setWhiteoooAllSquaresBb(computeAllEmptySquaresBb(whiteKing, Square.C1, whiteRookOOO, Square.D1));
+        setBlackooAllSquaresBb(computeAllEmptySquaresBb(blackKing, Square.G8, blackRookOO, Square.F8));
+        setBlackoooAllSquaresBb(computeAllEmptySquaresBb(blackKing, Square.C8, blackRookOOO, Square.D8));
+    }
+
+    /**
+     * Computes the squares the king passes through during castling (inclusive of destination, exclusive of start).
+     * These squares must not be attacked.
+     */
+    private static List<Square> computeKingPassSquares(Square kingFrom, Square kingTo) {
+        List<Square> squares = new ArrayList<>();
+        if (kingFrom == null || kingTo == null) return squares;
+        int fromFile = kingFrom.getFile().ordinal();
+        int toFile = kingTo.getFile().ordinal();
+        Rank rank = kingFrom.getRank();
+        if (fromFile == toFile) {
+            // King doesn't move (e.g., king on G1 doing O-O) - just include the destination
+            squares.add(kingTo);
+            return squares;
+        }
+        int step = fromFile < toFile ? 1 : -1;
+        // Include all squares from kingFrom+step to kingTo (inclusive)
+        for (int f = fromFile + step; ; f += step) {
+            squares.add(Square.encode(rank, File.allFiles[f]));
+            if (f == toFile) break;
+        }
+        return squares;
+    }
+
+    /**
+     * Computes the bitboard of all squares that must be empty for a Chess960 castle move.
+     * This includes squares between king start and king dest, and between rook start and rook dest,
+     * excluding the king and rook starting squares themselves.
+     */
+    private static long computeAllEmptySquaresBb(Square kingFrom, Square kingTo,
+                                                  Square rookFrom, Square rookTo) {
+        if (kingFrom == null || kingTo == null || rookFrom == null || rookTo == null) return 0L;
+        long bb = 0L;
+        Rank rank = kingFrom.getRank();
+
+        // Squares between king start and king dest (inclusive of both endpoints)
+        int kf1 = Math.min(kingFrom.getFile().ordinal(), kingTo.getFile().ordinal());
+        int kf2 = Math.max(kingFrom.getFile().ordinal(), kingTo.getFile().ordinal());
+        for (int f = kf1; f <= kf2; f++) {
+            bb |= Square.encode(rank, File.allFiles[f]).getBitboard();
+        }
+
+        // Squares between rook start and rook dest (inclusive of both endpoints)
+        int rf1 = Math.min(rookFrom.getFile().ordinal(), rookTo.getFile().ordinal());
+        int rf2 = Math.max(rookFrom.getFile().ordinal(), rookTo.getFile().ordinal());
+        for (int f = rf1; f <= rf2; f++) {
+            bb |= Square.encode(rank, File.allFiles[f]).getBitboard();
+        }
+
+        // Exclude king and rook starting squares (they are occupied by our own pieces that will move)
+        bb &= ~kingFrom.getBitboard();
+        bb &= ~rookFrom.getBitboard();
+
+        return bb;
+    }
+
+    /**
+     * Returns the file of the white king-side rook (for Shredder-FEN output).
+     * @return the file, or null if not set
+     */
+    public File getWhiteRookooFile() { return whiteRookooFile; }
+
+    /**
+     * Returns the file of the white queen-side rook (for Shredder-FEN output).
+     * @return the file, or null if not set
+     */
+    public File getWhiteRookoooFile() { return whiteRookoooFile; }
+
+    /**
+     * Returns the file of the black king-side rook (for Shredder-FEN output).
+     * @return the file, or null if not set
+     */
+    public File getBlackRookooFile() { return blackRookooFile; }
+
+    /**
+     * Returns the file of the black queen-side rook (for Shredder-FEN output).
+     * @return the file, or null if not set
+     */
+    public File getBlackRookoooFile() { return blackRookoooFile; }
 
     /**
      * Returns an unambiguous castle move by king given the provided side and castle rights, if possible. A castle move

--- a/src/main/java/com/github/bhlangonijr/chesslib/game/GameContext.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/game/GameContext.java
@@ -411,10 +411,33 @@ public class GameContext {
      * @return {@code true} if the move is a castle one
      */
     public boolean isCastleMove(final Move move) {
-        return move.equals(getWhiteoo()) ||
+        if (move.equals(getWhiteoo()) ||
                 move.equals(getWhiteooo()) ||
                 move.equals(getBlackoo()) ||
-                move.equals(getBlackooo());
+                move.equals(getBlackooo())) {
+            return true;
+        }
+        // Chess960: also detect king-to-rook-square notation (UCI convention)
+        // where the king moves to the rook's starting square instead of its final destination
+        if (getVariationType() == VariationType.CHESS960) {
+            if (whiteRookoo != null && move.getFrom().equals(getWhiteoo().getFrom())
+                    && move.getTo().equals(whiteRookoo.getFrom())) {
+                return true;
+            }
+            if (whiteRookooo != null && move.getFrom().equals(getWhiteooo().getFrom())
+                    && move.getTo().equals(whiteRookooo.getFrom())) {
+                return true;
+            }
+            if (blackRookoo != null && move.getFrom().equals(getBlackoo().getFrom())
+                    && move.getTo().equals(blackRookoo.getFrom())) {
+                return true;
+            }
+            if (blackRookooo != null && move.getFrom().equals(getBlackooo().getFrom())
+                    && move.getTo().equals(blackRookooo.getFrom())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -442,8 +465,21 @@ public class GameContext {
      * @return {@code true} if the move is a king-side castle one
      */
     public boolean isKingSideCastle(Move move) {
-        return move.equals(getWhiteoo()) ||
-                move.equals(getBlackoo());
+        if (move.equals(getWhiteoo()) || move.equals(getBlackoo())) {
+            return true;
+        }
+        // Chess960: king-to-rook-square notation for kingside
+        if (getVariationType() == VariationType.CHESS960) {
+            if (whiteRookoo != null && move.getFrom().equals(getWhiteoo().getFrom())
+                    && move.getTo().equals(whiteRookoo.getFrom())) {
+                return true;
+            }
+            if (blackRookoo != null && move.getFrom().equals(getBlackoo().getFrom())
+                    && move.getTo().equals(blackRookoo.getFrom())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveGenerator.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveGenerator.java
@@ -16,13 +16,20 @@
 
 package com.github.bhlangonijr.chesslib.move;
 
-import com.github.bhlangonijr.chesslib.*;
-
 import java.util.LinkedList;
 import java.util.List;
 
+import com.github.bhlangonijr.chesslib.Bitboard;
 import static com.github.bhlangonijr.chesslib.Bitboard.bitScanForward;
 import static com.github.bhlangonijr.chesslib.Bitboard.extractLsb;
+import com.github.bhlangonijr.chesslib.Board;
+import com.github.bhlangonijr.chesslib.CastleRight;
+import com.github.bhlangonijr.chesslib.Piece;
+import com.github.bhlangonijr.chesslib.PieceType;
+import com.github.bhlangonijr.chesslib.Rank;
+import com.github.bhlangonijr.chesslib.Side;
+import com.github.bhlangonijr.chesslib.Square;
+import com.github.bhlangonijr.chesslib.game.VariationType;
 
 /**
  * A handy collection of static utility methods for generating moves from a chess position.
@@ -340,9 +347,20 @@ public class MoveGenerator {
         if (board.isKingAttacked()) {
             return;
         }
+        boolean isChess960 = board.getContext().getVariationType() == VariationType.CHESS960;
         if (board.getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
                 (board.getCastleRight(side).equals(CastleRight.KING_SIDE))) {
-            if ((board.getBitboard() & board.getContext().getooAllSquaresBb(side)) == 0L) {
+            long occ = board.getBitboard();
+            if (isChess960) {
+                // Exclude king and rook from occupancy for the "must be empty" check
+                Move kingMove = board.getContext().getoo(side);
+                Move rookMove = board.getContext().getRookoo(side);
+                occ &= ~kingMove.getFrom().getBitboard();
+                if (rookMove != null) {
+                    occ &= ~rookMove.getFrom().getBitboard();
+                }
+            }
+            if ((occ & board.getContext().getooAllSquaresBb(side)) == 0L) {
                 if (!board.isSquareAttackedBy(board.getContext().getooSquares(side), side.flip())) {
                     moves.add(board.getContext().getoo(side));
                 }
@@ -350,7 +368,16 @@ public class MoveGenerator {
         }
         if (board.getCastleRight(side).equals(CastleRight.KING_AND_QUEEN_SIDE) ||
                 (board.getCastleRight(side).equals(CastleRight.QUEEN_SIDE))) {
-            if ((board.getBitboard() & board.getContext().getoooAllSquaresBb(side)) == 0L) {
+            long occ = board.getBitboard();
+            if (isChess960) {
+                Move kingMove = board.getContext().getooo(side);
+                Move rookMove = board.getContext().getRookooo(side);
+                occ &= ~kingMove.getFrom().getBitboard();
+                if (rookMove != null) {
+                    occ &= ~rookMove.getFrom().getBitboard();
+                }
+            }
+            if ((occ & board.getContext().getoooAllSquaresBb(side)) == 0L) {
                 if (!board.isSquareAttackedBy(board.getContext().getoooSquares(side), side.flip())) {
                     moves.add(board.getContext().getooo(side));
                 }

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -21,6 +21,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.github.bhlangonijr.chesslib.Bitboard;
 import com.github.bhlangonijr.chesslib.Board;
 import com.github.bhlangonijr.chesslib.Constants;
@@ -31,7 +33,6 @@ import com.github.bhlangonijr.chesslib.Rank;
 import com.github.bhlangonijr.chesslib.Side;
 import com.github.bhlangonijr.chesslib.Square;
 import com.github.bhlangonijr.chesslib.util.StringUtil;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A convenient data structure to store an ordered sequence of moves and access to their human-readable representation
@@ -136,14 +137,12 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
         StringBuilder san = new StringBuilder();
         Piece piece = board.getPiece(move.getFrom());
         if (piece.getPieceType().equals(PieceType.KING)) {
-            int delta = move.getTo().getFile().ordinal() -
-                    move.getFrom().getFile().ordinal();
-            if (Math.abs(delta) >= 2) { // is castle
+            if (board.getContext().isCastleMove(move)) { // Chess960-compatible castle detection
                 if (!board.doMove(move, true)) {
                     throw new MoveConversionException("Invalid move [" +
                             move + "] for current setup: " + board.getFen());
                 }
-                san.append(delta > 0 ? "O-O" : "O-O-O");
+                san.append(board.getContext().isKingSideCastle(move) ? "O-O" : "O-O-O");
                 addCheckFlag(board, san);
                 return san.toString();
             }

--- a/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
+++ b/src/main/java/com/github/bhlangonijr/chesslib/move/MoveList.java
@@ -483,14 +483,13 @@ public class MoveList extends LinkedList<Move> implements List<Move> {
             b.loadFromFen(getStartFen());
         }
         try {
-            Side side = b.getSideToMove();
             text = StringUtil.normalize(text);
             String[] m = text.split(StringUtils.SPACE);
             int i = 0;
             for (String strMove : m) {
-                Move move = new Move(strMove, side);
+                Move move = b.fromUci(strMove);
                 add(i++, move);
-                side = side.flip();
+                b.doMove(move);
             }
         } catch (Exception e) {
             throw new MoveConversionException("Couldn't parse text to MoveList: " + e.getMessage());

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960DoMoveBugTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960DoMoveBugTest.java
@@ -1,0 +1,236 @@
+package com.github.bhlangonijr.chesslib;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.github.bhlangonijr.chesslib.move.Move;
+
+/**
+ * Tests Chess960 castling via doMove() using king-to-rook-square notation (UCI convention).
+ * Covers various king/rook placements for both sides, kingside and queenside.
+ * <p>
+ * In Chess960 UCI notation, castling is encoded as king moves to the rook's square.
+ * After castling: king goes to g1/c1 (white) or g8/c8 (black),
+ * rook goes to f1/d1 (white) or f8/d8 (black).
+ */
+public class Chess960DoMoveBugTest {
+
+    // ========================================================================
+    // WHITE QUEENSIDE (O-O-O): King → C1, Rook → D1
+    // ========================================================================
+
+    @Test
+    public void testWhiteOOO_KingOnB_RookOnA() {
+        // King b1, rook a1 — the original bug case
+        assertCastling("8/8/8/8/8/8/8/RK6 w A - 0 1",
+                Square.B1, Square.A1,  // king moves to rook square
+                Square.C1, Square.D1); // expected final positions
+    }
+
+    @Test
+    public void testWhiteOOO_KingOnC_RookOnA() {
+        // King c1, rook a1 — king already on destination, rook moves
+        assertCastling("8/8/8/8/8/8/8/R1K5 w A - 0 1",
+                Square.C1, Square.A1,
+                Square.C1, Square.D1);
+    }
+
+    @Test
+    public void testWhiteOOO_KingOnD_RookOnA() {
+        // King d1, rook a1
+        assertCastling("8/8/8/8/8/8/8/R2K4 w A - 0 1",
+                Square.D1, Square.A1,
+                Square.C1, Square.D1);
+    }
+
+    @Test
+    public void testWhiteOOO_KingOnE_RookOnA() {
+        // King e1 (standard), rook a1
+        assertCastling("8/8/8/8/8/8/8/R3K3 w A - 0 1",
+                Square.E1, Square.A1,
+                Square.C1, Square.D1);
+    }
+
+    @Test
+    public void testWhiteOOO_KingOnF_RookOnA() {
+        // King f1, rook a1
+        assertCastling("8/8/8/8/8/8/8/R4K2 w A - 0 1",
+                Square.F1, Square.A1,
+                Square.C1, Square.D1);
+    }
+
+    @Test
+    public void testWhiteOOO_KingOnD_RookOnB() {
+        // King d1, rook b1
+        assertCastling("8/8/8/8/8/8/8/1R1K4 w B - 0 1",
+                Square.D1, Square.B1,
+                Square.C1, Square.D1);
+    }
+
+    @Test
+    public void testWhiteOOO_KingOnE_RookOnB() {
+        // King e1, rook b1
+        assertCastling("8/8/8/8/8/8/8/1R2K3 w B - 0 1",
+                Square.E1, Square.B1,
+                Square.C1, Square.D1);
+    }
+
+    // ========================================================================
+    // WHITE KINGSIDE (O-O): King → G1, Rook → F1
+    // ========================================================================
+
+    @Test
+    public void testWhiteOO_KingOnB_RookOnH() {
+        // King b1, rook h1
+        assertCastling("8/8/8/8/8/8/8/1K5R w H - 0 1",
+                Square.B1, Square.H1,
+                Square.G1, Square.F1);
+    }
+
+    @Test
+    public void testWhiteOO_KingOnE_RookOnH() {
+        // King e1 (standard), rook h1
+        assertCastling("8/8/8/8/8/8/8/4K2R w H - 0 1",
+                Square.E1, Square.H1,
+                Square.G1, Square.F1);
+    }
+
+    @Test
+    public void testWhiteOO_KingOnE_RookOnF() {
+        // King e1, rook f1 — adjacent, kingside
+        assertCastling("8/8/8/8/8/8/8/4KR2 w F - 0 1",
+                Square.E1, Square.F1,
+                Square.G1, Square.F1);
+    }
+
+    @Test
+    public void testWhiteOO_KingOnF_RookOnH() {
+        // King f1, rook h1
+        assertCastling("8/8/8/8/8/8/8/5K1R w H - 0 1",
+                Square.F1, Square.H1,
+                Square.G1, Square.F1);
+    }
+
+    @Test
+    public void testWhiteOO_KingOnF_RookOnG() {
+        // King f1, rook g1 — adjacent, kingside
+        assertCastling("8/8/8/8/8/8/8/5KR1 w G - 0 1",
+                Square.F1, Square.G1,
+                Square.G1, Square.F1);
+    }
+
+    @Test
+    public void testWhiteOO_KingOnD_RookOnF() {
+        // King d1, rook f1
+        assertCastling("8/8/8/8/8/8/8/3K1R2 w F - 0 1",
+                Square.D1, Square.F1,
+                Square.G1, Square.F1);
+    }
+
+    // ========================================================================
+    // BLACK QUEENSIDE (O-O-O): King → C8, Rook → D8
+    // ========================================================================
+
+    @Test
+    public void testBlackOOO_KingOnB_RookOnA() {
+        // King b8, rook a8
+        assertCastling("rk6/8/8/8/8/8/8/8 b a - 0 1",
+                Square.B8, Square.A8,
+                Square.C8, Square.D8);
+    }
+
+    @Test
+    public void testBlackOOO_KingOnD_RookOnA() {
+        // King d8, rook a8
+        assertCastling("r2k4/8/8/8/8/8/8/8 b a - 0 1",
+                Square.D8, Square.A8,
+                Square.C8, Square.D8);
+    }
+
+    @Test
+    public void testBlackOOO_KingOnE_RookOnB() {
+        // King e8, rook b8
+        assertCastling("1r2k3/8/8/8/8/8/8/8 b b - 0 1",
+                Square.E8, Square.B8,
+                Square.C8, Square.D8);
+    }
+
+    // ========================================================================
+    // BLACK KINGSIDE (O-O): King → G8, Rook → F8
+    // ========================================================================
+
+    @Test
+    public void testBlackOO_KingOnB_RookOnH() {
+        // King b8, rook h8
+        assertCastling("1k5r/8/8/8/8/8/8/8 b h - 0 1",
+                Square.B8, Square.H8,
+                Square.G8, Square.F8);
+    }
+
+    @Test
+    public void testBlackOO_KingOnE_RookOnH() {
+        // King e8 (standard), rook h8
+        assertCastling("4k2r/8/8/8/8/8/8/8 b h - 0 1",
+                Square.E8, Square.H8,
+                Square.G8, Square.F8);
+    }
+
+    @Test
+    public void testBlackOO_KingOnF_RookOnG() {
+        // King f8, rook g8 — adjacent
+        assertCastling("5kr1/8/8/8/8/8/8/8 b g - 0 1",
+                Square.F8, Square.G8,
+                Square.G8, Square.F8);
+    }
+
+    // ========================================================================
+    // Original bug case from game Rohith vs Kobalia
+    // ========================================================================
+
+    @Test
+    public void testOriginalBugPosition() {
+        String fen = "rkb1rbqn/pppp1ppp/2n1p3/2b1p3/2B1P3/1P2N3/PBPP1PPP/RK2R1QN w EAea - 4 5";
+        Board board = new Board();
+        board.loadFromFen(fen, true);
+
+        assertEquals(Square.B1, board.getKingSquare(Side.WHITE));
+
+        // O-O-O: king b1 → rook a1 (UCI notation)
+        Move castlingMove = new Move(Square.B1, Square.A1);
+        board.doMove(castlingMove);
+
+        assertEquals("King should be on C1", Square.C1, board.getKingSquare(Side.WHITE));
+        // Verify rook ended on D1
+        assertEquals("Rook should be on D1 after O-O-O",
+                Piece.WHITE_ROOK, board.getPiece(Square.D1));
+    }
+
+    // ========================================================================
+    // Helper
+    // ========================================================================
+
+    private void assertCastling(String fen, Square kingFrom, Square rookSquare,
+                                 Square expectedKingDest, Square expectedRookDest) {
+        Board board = new Board();
+        board.loadFromFen(fen, true);
+
+        assertEquals("King should start on " + kingFrom, kingFrom, board.getKingSquare(
+                kingFrom.getRank() == Rank.RANK_1 ? Side.WHITE : Side.BLACK));
+
+        // UCI Chess960 castling: king moves to rook's square
+        Move castlingMove = new Move(kingFrom, rookSquare);
+        boolean result = board.doMove(castlingMove);
+
+        assertTrue("doMove should succeed for castling " + kingFrom + "→" + rookSquare, result);
+
+        Side side = kingFrom.getRank() == Rank.RANK_1 ? Side.WHITE : Side.BLACK;
+        Square actualKing = board.getKingSquare(side);
+        assertEquals("King should end on " + expectedKingDest + " (was " + actualKing + ")",
+                expectedKingDest, actualKing);
+
+        Piece expectedRook = Piece.make(side, PieceType.ROOK);
+        assertEquals("Rook should be on " + expectedRookDest,
+                expectedRook, board.getPiece(expectedRookDest));
+    }
+}

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960FenComparisonTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960FenComparisonTest.java
@@ -1,0 +1,102 @@
+package com.github.bhlangonijr.chesslib;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import com.github.bhlangonijr.chesslib.move.Move;
+
+/**
+ * Tests documenting the exact FEN castling notation output of chesslib for Chess960.
+ * These tests serve as a reference for cross-library compatibility with chess.js.
+ * 
+ * KEY DIFFERENCE:
+ * - chesslib: ALWAYS uses file letters for Chess960 (e.g., "HFhf", "EHeh", "HAha")
+ * - chess.js: Uses K/Q/k/q for outermost rooks (a/h files), file letters for inner rooks
+ *   e.g., "HFhf" → chess.js outputs "KFkf" (H is outermost → K)
+ *   e.g., "EHeh" → chess.js outputs "KEke" (H is outermost → K)
+ *   e.g., "HAha" → chess.js outputs "KQkq" (both outermost → standard)
+ * 
+ * CONSEQUENCE: For FEN hash consistency, the frontend must use the FEN from the
+ * backend flat tree directly (enrichEvalsFromFlatTree), not recalculate with chess.js.
+ */
+public class Chess960FenComparisonTest {
+
+    @Test
+    public void testChesslibOutputForBqnbnrkr() {
+        // bqnbnrkr: King on G, Rooks on F(queen-side) and H(king-side)
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+        
+        String castling = board.getFen().split(" ")[2];
+        // chesslib: always file letters → "HFhf"
+        // chess.js: H is outermost → "KFkf"
+        assertEquals("chesslib always uses file letters", "HFhf", castling);
+    }
+
+    @Test
+    public void testChesslibOutputForBnqbrnkr() {
+        // bnqbrnkr: King on G, Rooks on E(queen-side) and H(king-side)
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w EHeh - 0 1");
+        
+        String castling = board.getFen().split(" ")[2];
+        // chesslib: "HEhe" (king-side first, then queen-side — based on code order)
+        // Wait, let's check: the code iterates KING_SIDE first, then QUEEN_SIDE
+        // King-side rook = H → "H", Queen-side rook = E → "E" → "HE" for white
+        // King-side rook = h → "h", Queen-side rook = e → "e" → "he" for black
+        assertEquals("chesslib outputs king-side first, then queen-side", "HEhe", castling);
+    }
+
+    @Test
+    public void testChesslibOutputForStandardPosition518() {
+        // Position 518 (standard starting position) loaded as Chess960
+        Board board = new Board();
+        board.loadFromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w HAha - 0 1");
+        
+        String castling = board.getFen().split(" ")[2];
+        // chesslib: H=king-side, A=queen-side → "HAha"
+        // chess.js: H is outermost, A is outermost → "KQkq"
+        assertEquals("chesslib uses file letters even for standard rook positions", "HAha", castling);
+    }
+
+    @Test
+    public void testChesslibOutputAfterMoves() {
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+        
+        board.doMove(new Move(Square.E2, Square.E4)); // 1. e4
+        String castling1 = board.getFen().split(" ")[2];
+        assertEquals("Castling preserved after e4", "HFhf", castling1);
+        
+        board.doMove(new Move(Square.E7, Square.E5)); // 1... e5
+        String castling2 = board.getFen().split(" ")[2];
+        assertEquals("Castling preserved after e5", "HFhf", castling2);
+    }
+
+    @Test
+    public void testChesslibKQkqWithChess960FlagProducesShredder() {
+        // Loading with KQkq + chess960=true should auto-detect rook positions
+        // and output Shredder-FEN
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w KQkq - 0 1", true);
+        
+        String castling = board.getFen().split(" ")[2];
+        assertEquals("KQkq + chess960 flag → Shredder-FEN", "HFhf", castling);
+    }
+
+    @Test
+    public void testFenNormalizationMustPreserveShredderNotation() {
+        // CRITICAL: The backend FenUtils.getNormalizedFen() keeps castling as-is.
+        // The frontend fenUtils.js getNormalizedFen() should do the same for Chess960 FEN.
+        // If the frontend converts Shredder→KQkq, the hash will NOT match the backend hash.
+        //
+        // This test verifies that chesslib's FEN output is consistent and can be
+        // used directly for hash computation without any conversion.
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/4P3/8/PPPP1PPP/BQNBNRKR b HFhf - 0 1");
+        
+        String fen = board.getFen();
+        String castling = fen.split(" ")[2];
+        assertEquals("Shredder notation preserved after reload", "HFhf", castling);
+    }
+}

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960KxcCaptureTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960KxcCaptureTest.java
@@ -1,0 +1,138 @@
+package com.github.bhlangonijr.chesslib;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+import com.github.bhlangonijr.chesslib.move.MoveList;
+
+/**
+ * Isolates the Chess960 Kxc1 problem from TWIC 1639 (Schnepp vs Niemann).
+ * FEN: rkqrbbnn/pppppppp/8/8/8/8/PPPPPPPP/RKQRBBNN w KQkq - 0 1
+ * 
+ * The game plays: 1.e4 e5 2.Ng3 Ng6 3.Nf3 c5 4.c3 Nf6 5.d4 cxd4 6.cxd4 Qxc1+ 7.Kxc1 exd4 8.Nxd4 d5
+ * Then 9.Nc2 fails.
+ *
+ * This test uses the stripped FEN (no castling rights) to simulate what the parser does.
+ */
+public class Chess960KxcCaptureTest {
+
+    private static final String START_FEN = "rkqrbbnn/pppppppp/8/8/8/8/PPPPPPPP/RKQRBBNN w KQkq - 0 1";
+    private static final String START_FEN_STRIPPED = "rkqrbbnn/pppppppp/8/8/8/8/PPPPPPPP/RKQRBBNN w - - 0 1";
+
+    /**
+     * Test: play moves 1-8 on the stripped FEN, then verify Nc2 is playable at move 9.
+     */
+    @Test
+    public void testNc2AfterKxc1OnStrippedFen() throws Exception {
+        // Play moves 1-8 one by one, getting FEN after each
+        String[] moves = {"e4", "e5", "Ng3", "Ng6", "Nf3", "c5", "c3", "Nf6", "d4", "cxd4", "cxd4", "Qxc1+", "Kxc1", "exd4", "Nxd4", "d5"};
+        
+        String currentFen = START_FEN_STRIPPED;
+        for (int i = 0; i < moves.length; i++) {
+            MoveList ml = new MoveList(currentFen);
+            try {
+                ml.loadFromSan(moves[i]);
+            } catch (Exception e) {
+                fail("Move " + moves[i] + " (index " + i + ") failed on FEN: " + currentFen + " — " + e.getMessage());
+            }
+            currentFen = ml.getFen();
+            System.out.println("After " + moves[i] + ": " + currentFen);
+        }
+
+        // Now try Nc2
+        System.out.println("\nFEN before Nc2: " + currentFen);
+        MoveList ml = new MoveList(currentFen);
+        try {
+            ml.loadFromSan("Nc2");
+            System.out.println("Nc2 succeeded! FEN after: " + ml.getFen());
+        } catch (Exception e) {
+            fail("Nc2 should be legal on FEN: " + currentFen + " — " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test: play moves 1-8 on the FULL FEN (with castling rights), then verify Nc2.
+     * This shows whether the castling rights cause the issue.
+     */
+    @Test
+    public void testNc2AfterKxc1OnFullFen() throws Exception {
+        String[] moves = {"e4", "e5", "Ng3", "Ng6", "Nf3", "c5", "c3", "Nf6", "d4", "cxd4", "cxd4", "Qxc1+", "Kxc1", "exd4", "Nxd4", "d5"};
+        
+        String currentFen = START_FEN;
+        for (int i = 0; i < moves.length; i++) {
+            MoveList ml = new MoveList(currentFen);
+            try {
+                ml.loadFromSan(moves[i]);
+            } catch (Exception e) {
+                fail("Move " + moves[i] + " (index " + i + ") failed on FEN: " + currentFen + " — " + e.getMessage());
+            }
+            currentFen = ml.getFen();
+            System.out.println("After " + moves[i] + ": " + currentFen);
+        }
+
+        System.out.println("\nFEN before Nc2: " + currentFen);
+        MoveList ml = new MoveList(currentFen);
+        try {
+            ml.loadFromSan("Nc2");
+            System.out.println("Nc2 succeeded! FEN after: " + ml.getFen());
+        } catch (Exception e) {
+            fail("Nc2 should be legal on FEN: " + currentFen + " — " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test: play all moves at once via loadFromSan on stripped FEN.
+     * This test verifies that the PGN from TWIC 1639 (Schnepp vs Niemann) has an illegal move
+     * at move 16 (Nc2) — the knight is already on c2 and no other knight can reach c2.
+     * This is a data error in TWIC, not a parser bug.
+     */
+    @Test
+    public void testAllMovesAtOnceStripped() throws Exception {
+        String allMoves = "1. e4 e5 2. Ng3 Ng6 3. Nf3 c5 4. c3 Nf6 5. d4 cxd4 6. cxd4 Qxc1+ 7. Kxc1 exd4 8. Nxd4 d5 9. Nc2 Kc7 10. exd5 Nxd5 11. b3 Ne5 12. Kb2 g6 13. Rac1 Bg7 14. Kb1 Nc6 15. Ne4 Nf4 16. Nc2 Nd3";
+        
+        MoveList ml = new MoveList(START_FEN_STRIPPED);
+        try {
+            ml.loadFromSan(allMoves);
+            fail("Should fail at move 16 Nc2 (illegal — c2 already occupied by own knight)");
+        } catch (Exception e) {
+            // Expected: Nc2 is illegal because c2 is already occupied by a white knight
+            assertTrue("Error should mention Nc2", e.getMessage().contains("Nc2"));
+        }
+    }
+
+    /**
+     * Test: Grieve vs Jeitz (TWIC 1639, partie 888).
+     * FEN: rnqnbkrb/pppppppp/8/8/8/8/PPPPPPPP/RNQNBKRB w KQkq - 0 1
+     * The game starts with 1. O-O and ends with 21. Nxe7+.
+     * Verifies if Nxe7+ is legal or if the PGN is incorrect.
+     */
+    @Test
+    public void testGrieveJeitzNxe7() throws Exception {
+        String fen = "rnqnbkrb/pppppppp/8/8/8/8/PPPPPPPP/RNQNBKRB w KQkq - 0 1";
+        String allMoves = "1. O-O d5 2. g3 Bc6 3. d4 Nd7 4. c4 Nf6 5. Ne3 Qd7 6. Nc3 dxc4 7. d5 Bb5 8. Nxb5 Qxb5 9. a4 Qd7 10. Qxc4 O-O 11. Rc1 Rc8 12. Bc3 c5 13. dxc6 Nxc6 14. Rfd1 Qc7 15. b4 Qb8 16. b5 Nd8 17. Nf5 Re8 18. Qb4 Kf8 19. Bxf6 gxf6 20. Qh4 Kg8 21. Nxe7+";
+
+        MoveList ml = new MoveList(fen);
+        try {
+            ml.loadFromSan(allMoves);
+            System.out.println("Grieve vs Jeitz: all moves legal! FEN: " + ml.getFen());
+        } catch (Exception e) {
+            // Find which move fails
+            String[] moves = allMoves.replaceAll("\\d+\\.\\s*", "").trim().split("\\s+");
+            String currentFen = fen;
+            for (int i = 0; i < moves.length; i++) {
+                if (moves[i].isEmpty() || moves[i].matches("\\d+\\..*")) continue;
+                MoveList tmp = new MoveList(currentFen);
+                try {
+                    tmp.loadFromSan(moves[i]);
+                    currentFen = tmp.getFen();
+                } catch (Exception e2) {
+                    System.out.println("FAILED at move '" + moves[i] + "' on FEN: " + currentFen);
+                    System.out.println("Error: " + e2.getMessage());
+                    fail("Move " + moves[i] + " failed: " + e2.getMessage());
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960RookMoveTest.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960RookMoveTest.java
@@ -1,0 +1,77 @@
+package com.github.bhlangonijr.chesslib;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.github.bhlangonijr.chesslib.game.VariationType;
+import com.github.bhlangonijr.chesslib.move.Move;
+import com.github.bhlangonijr.chesslib.move.MoveList;
+
+/**
+ * Minimal test to reproduce the Chess960 Ra1 bug from TWIC 1639 (Aronian vs Kumala).
+ * <p>
+ * The game starts from FEN: rkqrbbnn/pppppppp/8/8/8/8/PPPPPPPP/RKQRBBNN w KQkq - 0 1
+ * At move 43, White plays Ra1 (rook from a4 to a1) which is a simple rook move,
+ * but chesslib rejects it as illegal in Chess960 mode.
+ */
+public class Chess960RookMoveTest {
+
+    private static final String START_FEN = "rkqrbbnn/pppppppp/8/8/8/8/PPPPPPPP/RKQRBBNN w KQkq - 0 1";
+
+    // SAN moves for the first 42 moves (84 half-moves), before 43. Ra1
+    private static final String MOVES_SAN =
+            "1. d4 d5 2. f3 Bb5 3. a4 Ba6 4. Nf2 Ng6 5. Nd3 Bxd3 6. exd3 e6 7. f4 Bd6 8. g3 " +
+            "h5 9. Nf3 f6 10. c4 c6 11. Bh3 Qd7 12. Qe3 Re8 13. Nd2 Nh6 14. Qf3 h4 15. Nb3 " +
+            "Qf7 16. a5 a6 17. Ra4 Ka7 18. Bb4 Bxb4 19. Rxb4 hxg3 20. Nc5 Rab8 21. hxg3 Nf8 " +
+            "22. Rc1 f5 23. Qd1 Nd7 24. Na4 Qf6 25. Qd2 Nf7 26. Bg2 Nd6 27. Bf3 g6 28. Bd1 " +
+            "Rh8 29. Bb3 Rh3 30. Nb6 Nxb6 31. axb6+ Ka8 32. c5 Nf7 33. Rg1 Rbh8 34. Rg2 g5 " +
+            "35. Ka2 g4 36. Ra4 Kb8 37. Re2 Nd8 38. Rg2 R8h7 39. Bc2 Qh8 40. Kb3 Rh2 41. Rxh2 " +
+            "Rxh2 42. Qe3 Kc8";
+
+    /**
+     * Test that demonstrates the Chess960 fix: when the board is loaded with the initial
+     * Chess960 FEN (which has castling rights), the context defines castling as B8→C8.
+     * After castling rights are lost, the king can still move from B8 to C8 as a normal move.
+     * Previously this was rejected because isCastleMove matched the coordinates without
+     * checking castling rights.
+     */
+    @Test
+    public void testRa1IsLegalInChess960Position() throws Exception {
+        // Load the initial Chess960 position with castling rights
+        Board board = new Board();
+        board.loadFromFen(START_FEN, true);
+
+        assertTrue("Should be Chess960", board.getContext().getVariationType() == VariationType.CHESS960);
+
+        // The context defines blackooo = Move(B8, C8) for queen-side castling
+        Move blackOOO = board.getContext().getooo(Side.BLACK);
+        System.out.println("Black OOO (queen-side castle): " + blackOOO);
+        assertEquals("Black OOO should be B8->C8", new Move(Square.B8, Square.C8), blackOOO);
+
+        // Play all 84 half-moves via MoveList — this should now succeed
+        // (previously failed at move 42...Kc8 because it was confused with castling)
+        MoveList moveList = new MoveList(START_FEN);
+        moveList.loadFromSan(MOVES_SAN);
+        assertEquals("Should have 84 half-moves", 84, moveList.size());
+
+        // Get the FEN after 42 moves and verify Ra1 is legal
+        String fenBeforeRa1 = moveList.getFen();
+        System.out.println("FEN before 43. Ra1: " + fenBeforeRa1);
+
+        Board boardAfter42 = new Board();
+        boardAfter42.loadFromFen(fenBeforeRa1, true);
+
+        // Verify the rook is on a4 and a1 is empty
+        assertEquals("White rook should be on A4", Piece.WHITE_ROOK, boardAfter42.getPiece(Square.A4));
+        assertEquals("A1 should be empty", Piece.NONE, boardAfter42.getPiece(Square.A1));
+
+        // Ra1 should be legal
+        Move ra1 = new Move(Square.A4, Square.A1);
+        assertTrue("Ra1 (a4->a1) should be legal", boardAfter42.isMoveLegal(ra1, true));
+
+        // Play Ra1 and verify it succeeds
+        assertTrue("doMove(Ra1) should succeed", boardAfter42.doMove(ra1, true));
+        assertEquals("Rook should now be on A1", Piece.WHITE_ROOK, boardAfter42.getPiece(Square.A1));
+    }
+}

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960Test.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960Test.java
@@ -93,6 +93,26 @@ public class Chess960Test {
     }
 
     @Test
+    public void testChess960LoadFromTextUci() {
+        // loadFromText uses UCI notation — Chess960 castling is king→rook (g8h8)
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        MoveList moves = new MoveList(board.getFen());
+        // e4 e5 b3 Ng6 g3 O-O (O-O = king g8 to rook h8 in UCI Chess960)
+        moves.loadFromText("e2e4 e7e5 b2b3 f8g6 g2g3 g8h8");
+
+        assertEquals(6, moves.size());
+
+        // Replay and verify the castling happened correctly
+        for (Move m : moves) {
+            assertTrue("Move should be legal: " + m, board.doMove(m, true));
+        }
+        assertEquals(Piece.BLACK_KING, board.getPiece(Square.G8));
+        assertEquals(Piece.BLACK_ROOK, board.getPiece(Square.F8));
+    }
+
+    @Test
     public void testChess960FullGame() {
         Board board = new Board();
         board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
@@ -148,6 +168,43 @@ public class Chess960Test {
         // White should lose king-side castling right
         CastleRight cr = board2.getCastleRight(Side.WHITE);
         assertTrue(cr == CastleRight.QUEEN_SIDE || cr == CastleRight.NONE);
+    }
+
+    @Test
+    public void testChess960UciConversion() {
+        // Position: bnqbrnkr - King on G, Rooks on E and H
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        // O-O for white: king G1, rook H1 → UCI should be "g1h1" (king to rook)
+        Move whiteOO = board.getContext().getoo(Side.WHITE);
+        assertEquals("g1h1", board.toUci(whiteOO));
+
+        // O-O-O for white: king G1, rook E1 → UCI should be "g1e1"
+        Move whiteOOO = board.getContext().getooo(Side.WHITE);
+        assertEquals("g1e1", board.toUci(whiteOOO));
+
+        // fromUci: "g1h1" should be recognized as O-O
+        Move parsed = board.fromUci("g1h1");
+        assertEquals(whiteOO, parsed);
+
+        // fromUci: "g1e1" should be recognized as O-O-O
+        Move parsedOOO = board.fromUci("g1e1");
+        assertEquals(whiteOOO, parsedOOO);
+
+        // Normal move: "e2e4" should work as usual
+        Move e4 = board.fromUci("e2e4");
+        assertEquals(Square.E2, e4.getFrom());
+        assertEquals(Square.E4, e4.getTo());
+        assertEquals("e2e4", board.toUci(e4));
+    }
+
+    @Test
+    public void testStandardChessUciUnaffected() {
+        Board board = new Board();
+        // Standard chess: O-O is e1g1, not e1h1
+        Move whiteOO = board.getContext().getoo(Side.WHITE);
+        assertEquals("e1g1", board.toUci(whiteOO));
     }
 
     @Test

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960Test.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960Test.java
@@ -1,0 +1,196 @@
+package com.github.bhlangonijr.chesslib;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.github.bhlangonijr.chesslib.game.VariationType;
+import com.github.bhlangonijr.chesslib.move.Move;
+import com.github.bhlangonijr.chesslib.move.MoveList;
+
+public class Chess960Test {
+
+    @Test
+    public void testChess960Detection() {
+        // Position: bnqbrnkr - King on G1, Rooks on E1 and H1
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+        assertEquals(VariationType.CHESS960, board.getContext().getVariationType());
+    }
+
+    @Test
+    public void testChess960ShredderFenDetection() {
+        // Shredder-FEN with explicit rook files
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w EHeh - 0 1");
+        assertEquals(VariationType.CHESS960, board.getContext().getVariationType());
+    }
+
+    @Test
+    public void testChess960CastlingOO() {
+        // Position: bnqbrnkr - King on G1, Rooks on E1 and H1
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        // Play 1. e4 e5 2. b3 Ng6 3. g3
+        board.doMove(new Move(Square.E2, Square.E4));
+        board.doMove(new Move(Square.E7, Square.E5));
+        board.doMove(new Move(Square.B2, Square.B3));
+        board.doMove(new Move(Square.F8, Square.G6)); // Knight f8->g6
+        board.doMove(new Move(Square.G2, Square.G3));
+
+        // Black should be able to castle O-O (king G8, rook H8)
+        // O-O = king G8->G8 (stays!), rook H8->F8
+        Move castleMove = board.getContext().getoo(Side.BLACK);
+        assertNotNull(castleMove);
+        assertTrue(board.legalMoves().contains(castleMove));
+
+        // Execute the castle
+        assertTrue(board.doMove(castleMove));
+
+        // Verify: king on G8, rook on F8
+        assertEquals(Piece.BLACK_KING, board.getPiece(Square.G8));
+        assertEquals(Piece.BLACK_ROOK, board.getPiece(Square.F8));
+        assertEquals(Piece.NONE, board.getPiece(Square.H8));
+    }
+
+    @Test
+    public void testChess960CastlingUndo() {
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        board.doMove(new Move(Square.E2, Square.E4));
+        board.doMove(new Move(Square.E7, Square.E5));
+        board.doMove(new Move(Square.B2, Square.B3));
+        board.doMove(new Move(Square.F8, Square.G6));
+        board.doMove(new Move(Square.G2, Square.G3));
+
+        String fenBefore = board.getFen();
+
+        Move castleMove = board.getContext().getoo(Side.BLACK);
+        board.doMove(castleMove);
+
+        // Undo the castle
+        board.undoMove();
+
+        // Board should be back to the state before castling
+        assertEquals(fenBefore, board.getFen());
+        assertEquals(Piece.BLACK_KING, board.getPiece(Square.G8));
+        assertEquals(Piece.BLACK_ROOK, board.getPiece(Square.H8));
+    }
+
+    @Test
+    public void testChess960SanParsing() {
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        // Play moves via SAN
+        MoveList moves = new MoveList(board.getFen());
+        moves.loadFromSan("e4 e5 b3 Ng6 g3 O-O");
+
+        assertEquals(6, moves.size());
+    }
+
+    @Test
+    public void testChess960FullGame() {
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        MoveList moves = new MoveList(board.getFen());
+        moves.loadFromSan("e4 e5 b3 Ng6 g3 O-O");
+
+        for (Move m : moves) {
+            assertTrue("Move should be legal: " + m, board.doMove(m, true));
+        }
+    }
+
+    @Test
+    public void testChess960FenRoundTrip() {
+        // Load a Chess960 position and verify FEN round-trip
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w EHeh - 0 1");
+
+        String fen = board.getFen();
+        // Should output Shredder-FEN
+        assertTrue("FEN should contain Shredder-FEN castling: " + fen,
+                fen.contains("HE") || fen.contains("he"));
+
+        // Reload and verify
+        Board board2 = new Board();
+        board2.loadFromFen(fen);
+        assertEquals(VariationType.CHESS960, board2.getContext().getVariationType());
+    }
+
+    @Test
+    public void testChess960WhiteCastleOO() {
+        // White king on F1, rook on H1 - standard-ish O-O
+        Board board = new Board();
+        board.loadFromFen("rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQK2R w KQkq - 0 1");
+        // This is actually standard chess (king on E1), so it should NOT be Chess960
+        assertEquals(VariationType.NORMAL, board.getContext().getVariationType());
+    }
+
+    @Test
+    public void testChess960CastleRightsLostOnRookMove() {
+        Board board = new Board();
+        board.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+
+        // Move the h-side rook (H1)
+        board.doMove(new Move(Square.H1, Square.G1)); // This is actually the king square...
+        // Let's try a different approach - move a pawn first to open the rook
+        Board board2 = new Board();
+        board2.loadFromFen("bnqbrnkr/pppppppp/8/8/8/8/PPPPPPPP/BNQBRNKR w KQkq - 0 1");
+        board2.doMove(new Move(Square.H2, Square.H4));
+        board2.doMove(new Move(Square.A7, Square.A6));
+        board2.doMove(new Move(Square.H1, Square.H3)); // Move the h-rook
+
+        // White should lose king-side castling right
+        CastleRight cr = board2.getCastleRight(Side.WHITE);
+        assertTrue(cr == CastleRight.QUEEN_SIDE || cr == CastleRight.NONE);
+    }
+
+    @Test
+    public void testStandardChessUnaffected() {
+        // Verify standard chess still works
+        Board board = new Board();
+        board.loadFromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        assertEquals(VariationType.NORMAL, board.getContext().getVariationType());
+
+        // Play standard opening with castling
+        MoveList moves = new MoveList();
+        moves.loadFromSan("e4 e5 Nf3 Nc6 Bb5 a6 Ba4 Nf6 O-O");
+        for (Move m : moves) {
+            assertTrue(board.doMove(m, true));
+        }
+        assertEquals(Piece.WHITE_KING, board.getPiece(Square.G1));
+        assertEquals(Piece.WHITE_ROOK, board.getPiece(Square.F1));
+    }
+
+    @Test
+    public void testExplicitChess960FlagWithKingOnE() {
+        // Chess960 position 518 (identical to standard) but with rooks on B1 and F1
+        // King on E1, rooks NOT on A1/H1 — without the flag, KQkq would be treated as standard
+        String fen = "nrbkqbnr/pppppppp/8/8/8/8/PPPPPPPP/NRBKQBNR w KQkq - 0 1";
+
+        // Without flag: king on E1 → detected as standard (wrong for this position)
+        Board boardStd = new Board();
+        boardStd.loadFromFen(fen);
+        // King is not on E1 here actually... let me use a real position 518 variant
+        // Position where king IS on e1 but rooks are on b1 and f1
+        String fen960 = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RN1QKBNR w KQkq - 0 1";
+        // Actually let's use a cleaner example: king on E, rooks on B and H
+        String fenKingOnE = "qnrbknbr/pppppppp/8/8/8/8/PPPPPPPP/QNRBKNBR w KQkq - 0 1";
+
+        // With explicit flag: forced Chess960
+        Board board960 = new Board();
+        board960.loadFromFen(fenKingOnE, true);
+        assertEquals(VariationType.CHESS960, board960.getContext().getVariationType());
+
+        // Without flag: king on E but non-standard piece arrangement — still detected as NORMAL
+        // because king IS on e-file
+        Board boardNormal = new Board();
+        boardNormal.loadFromFen(fenKingOnE);
+        assertEquals(VariationType.NORMAL, boardNormal.getContext().getVariationType());
+    }
+}

--- a/src/test/java/com/github/bhlangonijr/chesslib/Chess960Test.java
+++ b/src/test/java/com/github/bhlangonijr/chesslib/Chess960Test.java
@@ -224,6 +224,207 @@ public class Chess960Test {
         assertEquals(Piece.WHITE_ROOK, board.getPiece(Square.F1));
     }
 
+    // ===== FEN FORMAT TESTS =====
+    // These tests verify the FEN output format for Chess960 positions,
+    // specifically the Shredder-FEN castling notation (file letters vs KQkq).
+
+    @Test
+    public void testShredderFenOutputWhenLoadedWithShredderFen() {
+        // Position: bqnbnrkr - King on G, Rooks on F and H
+        // Loaded with Shredder-FEN → getFen() should output Shredder-FEN
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+
+        String fen = board.getFen();
+        String castling = fen.split(" ")[2];
+        assertEquals("Shredder-FEN should be preserved", "HFhf", castling);
+    }
+
+    @Test
+    public void testShredderFenOutputWhenLoadedWithKQkqAndChess960Flag() {
+        // Same position loaded with KQkq + chess960=true
+        // getFen() should output Shredder-FEN (file letters) because the rook files are detected
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w KQkq - 0 1", true);
+
+        String fen = board.getFen();
+        String castling = fen.split(" ")[2];
+        assertEquals("Chess960 flag should produce Shredder-FEN", "HFhf", castling);
+    }
+
+    @Test
+    public void testKQkqOutputWhenLoadedWithKQkqWithoutFlag() {
+        // Same position loaded with KQkq WITHOUT chess960=true
+        // King is NOT on e-file → auto-detected as Chess960 → Shredder-FEN
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w KQkq - 0 1");
+
+        String fen = board.getFen();
+        String castling = fen.split(" ")[2];
+        // King on G-file (not E) → auto-detected as Chess960
+        assertEquals("Non-standard king position auto-detects Chess960", "HFhf", castling);
+    }
+
+    @Test
+    public void testShredderFenPreservedAfterMoves() {
+        // Load Chess960 position, play some moves, verify FEN stays in Shredder format
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+
+        board.doMove(new Move(Square.E2, Square.E4)); // 1. e4
+        String fen1 = board.getFen();
+        String castling1 = fen1.split(" ")[2];
+        assertEquals("Shredder-FEN preserved after pawn move", "HFhf", castling1);
+
+        board.doMove(new Move(Square.E7, Square.E5)); // 1... e5
+        String fen2 = board.getFen();
+        String castling2 = fen2.split(" ")[2];
+        assertEquals("Shredder-FEN preserved after black pawn move", "HFhf", castling2);
+    }
+
+    @Test
+    public void testShredderFenAfterCastlingRightsLost() {
+        // When one side loses castling rights, the remaining rights should still be Shredder
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+
+        // Move the H-rook (king-side) → lose king-side castling
+        board.doMove(new Move(Square.H2, Square.H4));
+        board.doMove(new Move(Square.A7, Square.A6));
+        board.doMove(new Move(Square.H1, Square.H3)); // Move H-rook
+
+        String fen = board.getFen();
+        String castling = fen.split(" ")[2];
+        // White should only have queen-side (F-file rook), black still has both
+        assertTrue("Castling should contain F for white queen-side: " + castling,
+                castling.contains("F"));
+        // White should have lost king-side (H) castling right
+        // Check that no uppercase H remains in the castling string
+        boolean hasWhiteKingSide = false;
+        for (char c : castling.toCharArray()) {
+            if (c == 'H') { hasWhiteKingSide = true; break; }
+        }
+        assertTrue("Castling should NOT contain H for white king-side: " + castling,
+                !hasWhiteKingSide);
+    }
+
+    @Test
+    public void testFenHashConsistencyBetweenShredderAndKQkqLoad() {
+        // CRITICAL: Verify that loading the same position with Shredder-FEN vs KQkq+flag
+        // produces the SAME getFen() output (both should be Shredder-FEN)
+        Board board1 = new Board();
+        board1.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+
+        Board board2 = new Board();
+        board2.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w KQkq - 0 1", true);
+
+        assertEquals("Both loading methods should produce identical FEN",
+                board1.getFen(), board2.getFen());
+    }
+
+    @Test
+    public void testShredderFenWithStandardRookPositions() {
+        // Position 518 (standard starting position) — rooks on A and H files
+        // Even in Chess960 mode, rooks on a/h should produce standard-looking Shredder-FEN
+        Board board = new Board();
+        board.loadFromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w HAha - 0 1");
+
+        String fen = board.getFen();
+        String castling = fen.split(" ")[2];
+        // H=king-side, A=queen-side → "HAha"
+        assertEquals("Standard rook positions in Shredder-FEN", "HAha", castling);
+    }
+
+    @Test
+    public void testFenRoundTripWithRealChess960Game() {
+        // Real game FEN from Freestyle Chess Grand Slam: bqnbnrkr position
+        String startFen = "bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1";
+        Board board = new Board();
+        board.loadFromFen(startFen);
+
+        // Play 1. c4 b6 2. b4 e6
+        board.doMove(new Move(Square.C2, Square.C4));
+        board.doMove(new Move(Square.B7, Square.B6));
+        board.doMove(new Move(Square.B2, Square.B4));
+        board.doMove(new Move(Square.E7, Square.E6));
+
+        // Get FEN after moves
+        String fenAfterMoves = board.getFen();
+
+        // Reload from that FEN and verify round-trip
+        Board board2 = new Board();
+        board2.loadFromFen(fenAfterMoves);
+        assertEquals("FEN round-trip should be identical", fenAfterMoves, board2.getFen());
+        assertEquals("Should still be Chess960", VariationType.CHESS960, board2.getContext().getVariationType());
+    }
+
+    // ===== EN PASSANT FEN TESTS =====
+    // These tests verify the en passant square behavior in FEN output.
+    // Standard FEN: always outputs ep square after double pawn push
+    // X-FEN: only outputs ep square when a legal en passant capture exists
+    // chesslib Board.getFen(): outputs ep square ALWAYS (standard FEN behavior)
+    // chesslib Board.getFen(true, true): outputs ep square only if capturable (X-FEN behavior)
+
+    @Test
+    public void testEnPassantAlwaysOutputByDefault() {
+        // After 1. e4, the ep square should be e3 even though no black pawn can capture
+        Board board = new Board();
+        board.doMove(new Move(Square.E2, Square.E4));
+        String fen = board.getFen();
+        String epField = fen.split(" ")[3];
+        assertEquals("Default getFen() always outputs ep square after double push", "e3", epField);
+    }
+
+    @Test
+    public void testEnPassantOnlyIfCapturableOption() {
+        // After 1. e4, with onlyOutputEnPassantIfCapturable=true, ep should be "-"
+        Board board = new Board();
+        board.doMove(new Move(Square.E2, Square.E4));
+        String fen = board.getFen(true, true);
+        String epField = fen.split(" ")[3];
+        assertEquals("getFen(true, true) omits ep when no capture possible", "-", epField);
+    }
+
+    @Test
+    public void testEnPassantOutputWhenCaptureExists() {
+        // After 1. e4 d5 2. e5 f5, the ep square f6 should be output in both modes
+        Board board = new Board();
+        board.doMove(new Move(Square.E2, Square.E4));
+        board.doMove(new Move(Square.D7, Square.D5));
+        board.doMove(new Move(Square.E4, Square.E5));
+        board.doMove(new Move(Square.F7, Square.F5)); // f5 next to e5 pawn
+
+        String fenDefault = board.getFen();
+        String epDefault = fenDefault.split(" ")[3];
+        assertEquals("Default: ep square present when capture exists", "f6", epDefault);
+
+        String fenStrict = board.getFen(true, true);
+        String epStrict = fenStrict.split(" ")[3];
+        assertEquals("Strict: ep square present when capture exists", "f6", epStrict);
+    }
+
+    @Test
+    public void testEnPassantChess960DefaultBehavior() {
+        // In Chess960, the default getFen() also always outputs ep square
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+        board.doMove(new Move(Square.E2, Square.E4));
+        String fen = board.getFen();
+        String epField = fen.split(" ")[3];
+        assertEquals("Chess960 default: ep square always output", "e3", epField);
+    }
+
+    @Test
+    public void testEnPassantChess960StrictBehavior() {
+        // In Chess960, getFen(true, true) omits ep when no capture possible
+        Board board = new Board();
+        board.loadFromFen("bqnbnrkr/pppppppp/8/8/8/8/PPPPPPPP/BQNBNRKR w HFhf - 0 1");
+        board.doMove(new Move(Square.E2, Square.E4));
+        String fen = board.getFen(true, true);
+        String epField = fen.split(" ")[3];
+        assertEquals("Chess960 strict: ep square omitted when no capture", "-", epField);
+    }
+
     @Test
     public void testExplicitChess960FlagWithKingOnE() {
         // Chess960 position 518 (identical to standard) but with rooks on B1 and F1


### PR DESCRIPTION
## Summary

Adds full Chess960 castling support to chesslib, including move generation, validation, execution, undo, SAN/UCI parsing, and FEN round-trip. All 960 starting positions are handled correctly.

Closes #122

## Changes

### Detection
- `Board.loadFromFen()` auto-detects Chess960 from Shredder-FEN (`AHah`) or `KQkq` with king not on e-file
- `Board.loadFromFen(fen, true)` forces Chess960 mode (useful when PGN has `[Variant "Chess960"]`)

### GameContext
- `loadChess960()` configures king/rook moves, traversed squares, and "must be empty" bitboards dynamically from actual piece positions

### Move execution
- `Board.doMove()` handles Chess960 castling with manual piece placement (avoids capture issues when king/rook are adjacent)
- `Board.isMoveLegal()` excludes king/rook from occupancy checks for castling validation
- `MoveBackup.restore()` handles Chess960 castle undo

### Move generation
- `MoveGenerator.generateCastleMoves()` excludes king/rook from occupancy checks

### UCI support
- `Board.toUci(Move)` returns king→rook notation for Chess960 castling (e.g. `g1h1`), following the official UCI Chess960 convention
- `Board.fromUci(String)` parses king→rook UCI notation as castling
- `MoveList.loadFromText()` uses `board.fromUci()` for correct Chess960 UCI parsing

### SAN support
- `MoveList.encode()` uses `context.isCastleMove()` instead of file-delta for castle detection (handles king moves of 0-1 files in Chess960)

### FEN
- `Board.getFen()` outputs Shredder-FEN castling rights for Chess960 positions

## Edge cases handled
- King already on destination (e.g. king on g1 doing O-O)
- King and rook adjacent or swapping squares
- Rook between king start and king destination
- Castle rights properly lost when rook or king moves

## Tests
14 new tests covering detection, castling O-O/O-O-O, undo, SAN parsing, UCI conversion, loadFromText, FEN round-trip, standard chess unaffected, and castle rights loss.

All 125 existing tests pass unchanged.
